### PR TITLE
fix: Improve Docker container health check in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,13 +192,26 @@ jobs:
         # Test that container starts and responds
         docker run --rm -d --name boxarr-ci-test -p 8899:8888 boxarr:test
         echo "Waiting for container to start..."
-        sleep 15
         
-        # Check if container is running
+        # Wait longer and retry health check
+        for i in {1..12}; do
+          sleep 10
+          echo "Health check attempt $i/12..."
+          if curl -f http://localhost:8899/api/health; then
+            echo "✅ Container is healthy!"
+            break
+          fi
+          if [ $i -eq 12 ]; then
+            echo "❌ Health check failed after 2 minutes"
+            echo "Container logs:"
+            docker logs boxarr-ci-test
+            docker stop boxarr-ci-test || true
+            exit 1
+          fi
+        done
+        
+        # Check if container is still running
         docker ps | grep boxarr-ci-test
-        
-        # Test health endpoint
-        curl -f http://localhost:8899/api/health || (docker logs boxarr-ci-test && exit 1)
         
         # Clean up
         docker stop boxarr-ci-test || true


### PR DESCRIPTION
## 🔧 CI Pipeline Fix

### Problem
The CI pipeline was failing on the "Docker Build Test" step because:
- Container needed more time to start in GitHub Actions environment  
- 15-second timeout was insufficient
- No retry logic for transient startup issues

### Solution
- **Increased timeout**: 15s → 2 minutes total
- **Added retry loop**: 12 attempts with 10-second intervals
- **Better error reporting**: Shows container logs on failure
- **More robust health checking**: Proper feedback and status

### Testing
✅ Docker image builds and runs correctly locally
✅ Container starts properly but needs 30-60 seconds in CI environment
✅ Health endpoint responds correctly: `{"status":"healthy",...}`

The Docker image is working fine, just needed more patience in the CI environment.

## Impact
- ✅ CI pipeline should now pass consistently
- ⏱️ Slightly longer CI time (up to 2 min vs 15s timeout) 
- 🔍 Better debugging when issues occur