### PR TITLE
Fix APScheduler day numbering in settings UI

### DIFF
--- a/src/api/routes/web.py
+++ b/src/api/routes/web.py
@@ -82,17 +82,21 @@ async def dashboard_page(request: Request):
         )
         if cron_match:
             hour = int(cron_match.group(2))
-            day = int(cron_match.group(3))
-            days = [
-                "Sunday",
-                "Monday",
-                "Tuesday",
-                "Wednesday",
-                "Thursday",
-                "Friday",
-                "Saturday",
-            ]
-            next_update = f"{days[day]} at {hour}:00"
+            apscheduler_day = int(cron_match.group(3))
+            
+            # Convert APScheduler day to day name
+            # APScheduler: Monday=0, Tuesday=1, ..., Saturday=5, Sunday=6
+            apscheduler_days = {
+                0: "Monday",
+                1: "Tuesday",
+                2: "Wednesday",
+                3: "Thursday",
+                4: "Friday",
+                5: "Saturday",
+                6: "Sunday"
+            }
+            day_name = apscheduler_days.get(apscheduler_day, "Unknown")
+            next_update = f"{day_name} at {hour}:00"
 
     return templates.TemplateResponse(
         "dashboard.html",
@@ -122,8 +126,22 @@ async def setup_page(request: Request):
     cron_match = re.match(r"(\d+) (\d+) \* \* (\d+)", cron)
 
     # Extract current cron settings
-    current_day = int(cron_match.group(3)) if cron_match else 2
+    apscheduler_day = int(cron_match.group(3)) if cron_match else 1  # Default Tuesday (APScheduler format)
     current_time = int(cron_match.group(2)) if cron_match else 23
+    
+    # Convert APScheduler day numbering to HTML form values
+    # APScheduler: Monday=0, Tuesday=1, ..., Saturday=5, Sunday=6
+    # HTML form: Sunday=0, Monday=1, ..., Saturday=6
+    apscheduler_to_html = {
+        0: 1,  # Monday: 0 -> 1
+        1: 2,  # Tuesday: 1 -> 2
+        2: 3,  # Wednesday: 2 -> 3
+        3: 4,  # Thursday: 3 -> 4
+        4: 5,  # Friday: 4 -> 5
+        5: 6,  # Saturday: 5 -> 6
+        6: 0   # Sunday: 6 -> 0
+    }
+    current_day = apscheduler_to_html.get(apscheduler_day, 2)  # Default to Tuesday if unknown
 
     return templates.TemplateResponse(
         "setup.html",

--- a/src/api/routes/web.py
+++ b/src/api/routes/web.py
@@ -83,7 +83,7 @@ async def dashboard_page(request: Request):
         if cron_match:
             hour = int(cron_match.group(2))
             apscheduler_day = int(cron_match.group(3))
-            
+
             # Convert APScheduler day to day name
             # APScheduler: Monday=0, Tuesday=1, ..., Saturday=5, Sunday=6
             apscheduler_days = {
@@ -93,7 +93,7 @@ async def dashboard_page(request: Request):
                 3: "Thursday",
                 4: "Friday",
                 5: "Saturday",
-                6: "Sunday"
+                6: "Sunday",
             }
             day_name = apscheduler_days.get(apscheduler_day, "Unknown")
             next_update = f"{day_name} at {hour}:00"
@@ -126,9 +126,11 @@ async def setup_page(request: Request):
     cron_match = re.match(r"(\d+) (\d+) \* \* (\d+)", cron)
 
     # Extract current cron settings
-    apscheduler_day = int(cron_match.group(3)) if cron_match else 1  # Default Tuesday (APScheduler format)
+    apscheduler_day = (
+        int(cron_match.group(3)) if cron_match else 1
+    )  # Default Tuesday (APScheduler format)
     current_time = int(cron_match.group(2)) if cron_match else 23
-    
+
     # Convert APScheduler day numbering to HTML form values
     # APScheduler: Monday=0, Tuesday=1, ..., Saturday=5, Sunday=6
     # HTML form: Sunday=0, Monday=1, ..., Saturday=6
@@ -139,9 +141,11 @@ async def setup_page(request: Request):
         3: 4,  # Thursday: 3 -> 4
         4: 5,  # Friday: 4 -> 5
         5: 6,  # Saturday: 5 -> 6
-        6: 0   # Sunday: 6 -> 0
+        6: 0,  # Sunday: 6 -> 0
     }
-    current_day = apscheduler_to_html.get(apscheduler_day, 2)  # Default to Tuesday if unknown
+    current_day = apscheduler_to_html.get(
+        apscheduler_day, 2
+    )  # Default to Tuesday if unknown
 
     return templates.TemplateResponse(
         "setup.html",

--- a/src/web/static/js/app.js
+++ b/src/web/static/js/app.js
@@ -852,13 +852,25 @@ function reloadScheduler() {
         
         // Convert scheduler day and time to cron format
         if (schedulerDay && schedulerTime) {
-            // Cron format: minute hour * * day_of_week
-            // Day of week: 0=Sunday, 1=Monday, ..., 6=Saturday
-            const cronString = `0 ${schedulerTime.value} * * ${schedulerDay.value}`;
+            // APScheduler uses different day numbering than standard cron:
+            // APScheduler: Monday=0, Tuesday=1, ..., Saturday=5, Sunday=6
+            // HTML form uses: Sunday=0, Monday=1, ..., Saturday=6
+            // We need to convert from HTML form values to APScheduler values
+            const dayMapping = {
+                '0': '6', // Sunday: 0 -> 6
+                '1': '0', // Monday: 1 -> 0
+                '2': '1', // Tuesday: 2 -> 1
+                '3': '2', // Wednesday: 3 -> 2
+                '4': '3', // Thursday: 4 -> 3
+                '5': '4', // Friday: 5 -> 4
+                '6': '5'  // Saturday: 6 -> 5
+            };
+            const apschedulerDay = dayMapping[schedulerDay.value] || schedulerDay.value;
+            const cronString = `0 ${schedulerTime.value} * * ${apschedulerDay}`;
             config.boxarr_scheduler_cron = cronString;
         } else {
-            // Default: Tuesday at 11 PM
-            config.boxarr_scheduler_cron = "0 23 * * 2";
+            // Default: Tuesday at 11 PM (APScheduler day 1)
+            config.boxarr_scheduler_cron = "0 23 * * 1";
         }
         
         showMessage('Saving configuration...', 'info');


### PR DESCRIPTION
## Summary
- Fixed incorrect day-of-week mapping between HTML form values and APScheduler cron format
- Scheduler now correctly runs on the selected day instead of one day late

## Problem
The settings UI was using standard cron day numbering (Sunday=0, Saturday=6) but APScheduler uses a different convention (Monday=0, Sunday=6). This caused scheduled tasks to run on the wrong day - for example, selecting Saturday would actually schedule for Sunday.

## Solution
Added a day mapping conversion in the JavaScript code that translates HTML form values to APScheduler's expected format:
- HTML form: Sunday=0, Monday=1, ..., Saturday=6
- APScheduler: Monday=0, Tuesday=1, ..., Saturday=5, Sunday=6

## Test Plan
- [x] Verified scheduler now runs on Saturday when Saturday is selected
- [x] Confirmed correct cron expression is saved to config
- [x] Tested all days of the week map correctly

🤖 Generated with [Claude Code](https://claude.ai/code)