### PR TITLE
Fix dashboard pagination and add year filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Improved Dashboard Pagination**: Complete overhaul of weekly card display system (#18)
+  - **Proper Pagination**: Navigate through pages with Previous/Next buttons and page numbers
+  - **Configurable Page Size**: Choose to display 10, 20, 50, or 100 cards per page (default: 10)
+  - **Year Filtering**: Filter weekly cards by year with dedicated filter buttons
+  - **Smart Navigation**: Page numbers show current page ± 2 with ellipsis for gaps
 - **Advanced Auto-Add Filtering**: Comprehensive filtering options for automatic movie additions (#16)
   - **Top X Movies Limit**: Choose to add only the top 1-10 movies from box office rankings
   - **Genre Filtering**: Whitelist or blacklist specific genres (19 common genres pre-populated)
@@ -16,10 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Expandable Settings UI**: Auto-add options only appear when feature is enabled
 
 ### Fixed
+- **Dashboard Navigation**: Replaced limited dropdown system with full pagination controls (#18)
 - **UI Bug**: Movies already in Radarr no longer show "Add to Radarr" button when JSON is outdated
 - **Status Updates**: Weekly pages now correctly update movie status by matching on title when radarr_id is missing
 
 ### Changed
+- **Dashboard Layout**: Removed old "6 cards + dropdown" system in favor of paginated display (#18)
 - **Historical Fetch Modals**: Removed confusing auto-add override option, now shows current settings with link to Settings page
 - **Improved Logging**: Added detailed logging showing why movies are filtered out during auto-add
 

--- a/src/api/routes/web.py
+++ b/src/api/routes/web.py
@@ -64,7 +64,7 @@ async def dashboard_page(request: Request):
     # Get query parameters for pagination and filtering
     page = int(request.query_params.get("page", 1))
     per_page = int(request.query_params.get("per_page", 10))
-    year_filter = request.query_params.get("year", None)
+    year_filter_str = request.query_params.get("year", None)
 
     # Validate per_page
     if per_page not in [10, 20, 50, 100]:
@@ -74,12 +74,12 @@ async def dashboard_page(request: Request):
     all_weeks = await get_available_weeks()
 
     # Apply year filter if specified
-    if year_filter and year_filter.isdigit():
-        year_filter = int(year_filter)
+    year_filter: Optional[int] = None
+    if year_filter_str and year_filter_str.isdigit():
+        year_filter = int(year_filter_str)
         weeks = [w for w in all_weeks if w.year == year_filter]
     else:
         weeks = all_weeks
-        year_filter = None
 
     # Get unique years for filter buttons
     available_years = sorted(list(set(w.year for w in all_weeks)), reverse=True)
@@ -95,7 +95,7 @@ async def dashboard_page(request: Request):
 
     # For backward compatibility, keep these but empty
     recent_weeks = paginated_weeks
-    older_weeks = []
+    older_weeks: List[WeekInfo] = []
 
     # Calculate next scheduled update
     from datetime import datetime

--- a/src/api/routes/web.py
+++ b/src/api/routes/web.py
@@ -65,14 +65,14 @@ async def dashboard_page(request: Request):
     page = int(request.query_params.get("page", 1))
     per_page = int(request.query_params.get("per_page", 10))
     year_filter = request.query_params.get("year", None)
-    
+
     # Validate per_page
     if per_page not in [10, 20, 50, 100]:
         per_page = 10
-    
+
     # Get all available weeks
     all_weeks = await get_available_weeks()
-    
+
     # Apply year filter if specified
     if year_filter and year_filter.isdigit():
         year_filter = int(year_filter)
@@ -80,19 +80,19 @@ async def dashboard_page(request: Request):
     else:
         weeks = all_weeks
         year_filter = None
-    
+
     # Get unique years for filter buttons
     available_years = sorted(list(set(w.year for w in all_weeks)), reverse=True)
-    
+
     # Calculate pagination
     total_weeks = len(weeks)
     total_pages = (total_weeks + per_page - 1) // per_page  # Ceiling division
     page = max(1, min(page, total_pages))  # Ensure page is within bounds
-    
+
     start_idx = (page - 1) * per_page
     end_idx = start_idx + per_page
     paginated_weeks = weeks[start_idx:end_idx]
-    
+
     # For backward compatibility, keep these but empty
     recent_weeks = paginated_weeks
     older_weeks = []

--- a/src/api/routes/web.py
+++ b/src/api/routes/web.py
@@ -61,13 +61,41 @@ async def dashboard_page(request: Request):
     if not settings.is_configured:
         return RedirectResponse(url="/setup")
 
+    # Get query parameters for pagination and filtering
+    page = int(request.query_params.get("page", 1))
+    per_page = int(request.query_params.get("per_page", 10))
+    year_filter = request.query_params.get("year", None)
+    
+    # Validate per_page
+    if per_page not in [10, 20, 50, 100]:
+        per_page = 10
+    
     # Get all available weeks
-    weeks = await get_available_weeks()
-
-    # Separate into recent (first 6) and older
-    # Changed from 24 to 6 to make the dropdown accessible sooner
-    recent_weeks = weeks[:6]
-    older_weeks = weeks[6:] if len(weeks) > 6 else []
+    all_weeks = await get_available_weeks()
+    
+    # Apply year filter if specified
+    if year_filter and year_filter.isdigit():
+        year_filter = int(year_filter)
+        weeks = [w for w in all_weeks if w.year == year_filter]
+    else:
+        weeks = all_weeks
+        year_filter = None
+    
+    # Get unique years for filter buttons
+    available_years = sorted(list(set(w.year for w in all_weeks)), reverse=True)
+    
+    # Calculate pagination
+    total_weeks = len(weeks)
+    total_pages = (total_weeks + per_page - 1) // per_page  # Ceiling division
+    page = max(1, min(page, total_pages))  # Ensure page is within bounds
+    
+    start_idx = (page - 1) * per_page
+    end_idx = start_idx + per_page
+    paginated_weeks = weeks[start_idx:end_idx]
+    
+    # For backward compatibility, keep these but empty
+    recent_weeks = paginated_weeks
+    older_weeks = []
 
     # Calculate next scheduled update
     from datetime import datetime
@@ -139,7 +167,7 @@ async def dashboard_page(request: Request):
             "weeks": weeks,
             "recent_weeks": recent_weeks,
             "older_weeks": older_weeks,
-            "total_weeks": len(weeks),
+            "total_weeks": total_weeks,
             "radarr_configured": bool(settings.radarr_api_key),
             "scheduler_enabled": settings.boxarr_scheduler_enabled,
             "auto_add": settings.boxarr_features_auto_add,
@@ -148,6 +176,14 @@ async def dashboard_page(request: Request):
             "version": __version__,
             "auto_add_filters_active": auto_add_filters_active,
             "filter_descriptions": filter_descriptions,
+            # Pagination data
+            "current_page": page,
+            "total_pages": total_pages,
+            "per_page": per_page,
+            "paginated_weeks": paginated_weeks,
+            "available_years": available_years,
+            "year_filter": year_filter,
+            "total_all_weeks": len(all_weeks),
         },
     )
 

--- a/src/web/static/js/app.js
+++ b/src/web/static/js/app.js
@@ -606,6 +606,13 @@ function reloadScheduler() {
         }
     };
 
+    window.changePageSize = function(newSize) {
+        const urlParams = new URLSearchParams(window.location.search);
+        urlParams.set('per_page', newSize);
+        urlParams.set('page', '1'); // Reset to first page when changing page size
+        window.location.href = `/dashboard?${urlParams.toString()}`;
+    };
+
     // ==========================================
     // Weekly Page Functions
     // ==========================================

--- a/src/web/templates/dashboard.html
+++ b/src/web/templates/dashboard.html
@@ -450,6 +450,145 @@
     border-top: 1px solid var(--border-color);
     text-align: center;
 }
+
+/* Pagination and Filter Styles */
+.filter-section {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1.5rem;
+    margin-bottom: 2rem;
+    box-shadow: var(--shadow);
+}
+
+.filter-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.year-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.year-filter-label {
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-right: 0.5rem;
+}
+
+.year-btn {
+    padding: 0.5rem 1rem;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    color: var(--text-primary);
+    text-decoration: none;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.year-btn:hover {
+    background: var(--bg-color);
+    transform: translateY(-1px);
+}
+
+.year-btn.active {
+    background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
+    color: white;
+    border-color: transparent;
+}
+
+.page-size-selector {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.page-size-selector label {
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.page-size-select {
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    background: var(--card-bg);
+    color: var(--text-primary);
+    font-size: 0.95rem;
+    cursor: pointer;
+}
+
+.pagination-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+    margin: 2rem 0;
+    padding: 1.5rem;
+    background: var(--card-bg);
+    border-radius: 12px;
+    border: 1px solid var(--border-color);
+    box-shadow: var(--shadow);
+}
+
+.pagination {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.page-link {
+    padding: 0.5rem 0.75rem;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    color: var(--text-primary);
+    text-decoration: none;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s;
+    min-width: 40px;
+    text-align: center;
+}
+
+.page-link:hover:not(.disabled):not(.active) {
+    background: var(--bg-color);
+    transform: translateY(-1px);
+}
+
+.page-link.active {
+    background: linear-gradient(135deg, var(--primary-color), var(--secondary-color));
+    color: white;
+    border-color: transparent;
+}
+
+.page-link.disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.page-info {
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    margin: 0 1rem;
+}
+
+.filter-info {
+    padding: 0.75rem;
+    background: rgba(var(--primary-rgb), 0.05);
+    border-radius: 8px;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
+    color: var(--text-primary);
+}
 </style>
 {% endblock %}
 
@@ -494,7 +633,7 @@
             
             <div class="status-item">
                 <span class="status-label">Weekly Pages:</span>
-                <span class="status-value highlight">{{ total_weeks }}</span>
+                <span class="status-value highlight">{{ total_all_weeks }}</span>
             </div>
         </div>
         
@@ -543,13 +682,46 @@
         </div>
     </div>
     
+    <!-- Filters and Pagination Controls -->
+    {% if weeks %}
+    <div class="filter-section">
+        <div class="filter-controls">
+            <div class="year-filters">
+                <span class="year-filter-label">Filter by year:</span>
+                <a href="/dashboard?page=1&per_page={{ per_page }}" 
+                   class="year-btn {% if not year_filter %}active{% endif %}">All</a>
+                {% for year in available_years %}
+                <a href="/dashboard?year={{ year }}&page=1&per_page={{ per_page }}" 
+                   class="year-btn {% if year_filter == year %}active{% endif %}">{{ year }}</a>
+                {% endfor %}
+            </div>
+            
+            <div class="page-size-selector">
+                <label for="perPageSelect">Show:</label>
+                <select id="perPageSelect" class="page-size-select" onchange="changePageSize(this.value)">
+                    <option value="10" {% if per_page == 10 %}selected{% endif %}>10 per page</option>
+                    <option value="20" {% if per_page == 20 %}selected{% endif %}>20 per page</option>
+                    <option value="50" {% if per_page == 50 %}selected{% endif %}>50 per page</option>
+                    <option value="100" {% if per_page == 100 %}selected{% endif %}>100 per page</option>
+                </select>
+            </div>
+        </div>
+        
+        {% if year_filter %}
+        <div class="filter-info">
+            <strong>Showing {{ total_weeks }} weeks from {{ year_filter }}</strong>
+        </div>
+        {% endif %}
+    </div>
+    {% endif %}
+    
     <!-- Weekly Reports -->
     <div class="reports-container">
         {% if weeks %}
             <h2 class="section-title">Weekly Box Office Reports</h2>
             
             <div class="reports-grid">
-                {% for week in recent_weeks %}
+                {% for week in paginated_weeks %}
                 <div class="report-card">
                     <div class="report-header">
                         <h3>Week {{ "%02d"|format(week.week) }}, {{ week.year }}</h3>
@@ -580,32 +752,61 @@
                 {% endfor %}
             </div>
             
-            {% if older_weeks %}
-            <div class="older-weeks">
-                <p>Showing {{ recent_weeks|length }} recent weeks • <strong>{{ older_weeks|length }}</strong> older weeks available</p>
-                <select class="week-selector" onchange="if(this.value) showHistoricalWeekModal(this.value, this.options[this.selectedIndex].text); this.selectedIndex = 0;">
-                    <option value="">View older weeks...</option>
-                    {% for week in older_weeks %}
-                    <option value="/{{ week.year }}W{{ '%02d'|format(week.week) }}">Week {{ "%02d"|format(week.week) }}, {{ week.year }} - {{ week.date_range }}</option>
+            <!-- Pagination -->
+            {% if total_pages > 1 %}
+            <div class="pagination-container">
+                <div class="pagination">
+                    <!-- Previous button -->
+                    {% if current_page > 1 %}
+                    <a href="/dashboard?page={{ current_page - 1 }}&per_page={{ per_page }}{% if year_filter %}&year={{ year_filter }}{% endif %}" 
+                       class="page-link">← Previous</a>
+                    {% else %}
+                    <span class="page-link disabled">← Previous</span>
+                    {% endif %}
+                    
+                    <!-- Page numbers -->
+                    {% set start_page = current_page - 2 %}
+                    {% if start_page < 1 %}{% set start_page = 1 %}{% endif %}
+                    {% set end_page = current_page + 2 %}
+                    {% if end_page > total_pages %}{% set end_page = total_pages %}{% endif %}
+                    
+                    {% if start_page > 1 %}
+                    <a href="/dashboard?page=1&per_page={{ per_page }}{% if year_filter %}&year={{ year_filter }}{% endif %}" 
+                       class="page-link">1</a>
+                    {% if start_page > 2 %}
+                    <span class="page-link disabled">...</span>
+                    {% endif %}
+                    {% endif %}
+                    
+                    {% for page_num in range(start_page, end_page + 1) %}
+                    {% if page_num == current_page %}
+                    <span class="page-link active">{{ page_num }}</span>
+                    {% else %}
+                    <a href="/dashboard?page={{ page_num }}&per_page={{ per_page }}{% if year_filter %}&year={{ year_filter }}{% endif %}" 
+                       class="page-link">{{ page_num }}</a>
+                    {% endif %}
                     {% endfor %}
-                </select>
-                <div style="margin-top: 1rem; padding: 1rem; background: rgba(var(--primary-rgb), 0.05); border-radius: 8px; border: 1px solid rgba(var(--primary-rgb), 0.2);">
-                    <p style="font-size: 0.9rem; color: var(--text-primary); margin-bottom: 0.5rem;">
-                        <strong>📊 What happens when you select a historical week:</strong>
-                    </p>
-                    <ol style="font-size: 0.85rem; color: var(--text-secondary); margin: 0; padding-left: 1.5rem;">
-                        <li>Box office data for that week will be fetched from Box Office Mojo</li>
-                        <li>Movies will be matched against your Radarr library</li>
-                        {% if auto_add %}
-                        <li style="color: var(--success-color); font-weight: 600;">✅ Missing movies will be AUTOMATICALLY added to Radarr</li>
-                        {% else %}
-                        <li style="color: var(--warning-color); font-weight: 600;">🔘 You will need to MANUALLY add movies to Radarr</li>
-                        {% endif %}
-                    </ol>
-                    <p style="font-size: 0.85rem; color: var(--text-secondary); margin-top: 0.5rem; margin-bottom: 0;">
-                        💡 <strong>Current setting:</strong> Auto-add is {% if auto_add %}<span style="color: var(--success-color);">ENABLED</span>{% else %}<span style="color: var(--warning-color);">DISABLED</span>{% endif %}
-                    </p>
+                    
+                    {% if end_page < total_pages %}
+                    {% if end_page < total_pages - 1 %}
+                    <span class="page-link disabled">...</span>
+                    {% endif %}
+                    <a href="/dashboard?page={{ total_pages }}&per_page={{ per_page }}{% if year_filter %}&year={{ year_filter }}{% endif %}" 
+                       class="page-link">{{ total_pages }}</a>
+                    {% endif %}
+                    
+                    <!-- Next button -->
+                    {% if current_page < total_pages %}
+                    <a href="/dashboard?page={{ current_page + 1 }}&per_page={{ per_page }}{% if year_filter %}&year={{ year_filter }}{% endif %}" 
+                       class="page-link">Next →</a>
+                    {% else %}
+                    <span class="page-link disabled">Next →</span>
+                    {% endif %}
                 </div>
+                
+                <span class="page-info">
+                    Page {{ current_page }} of {{ total_pages }} | Showing {{ paginated_weeks|length }} of {{ total_weeks }} weeks
+                </span>
             </div>
             {% endif %}
         {% else %}


### PR DESCRIPTION
## Summary
This PR implements proper pagination for the dashboard weekly cards display, replacing the limited "6 cards + dropdown" system with a full-featured pagination interface with year filtering.

Fixes #18

## Changes
- ✅ Added proper pagination with Previous/Next buttons and page numbers
- ✅ Implemented configurable page size selector (10/20/50/100 cards per page)
- ✅ Added year filter buttons to filter cards by specific year
- ✅ Default page size set to 10 as requested
- ✅ Smart page number display (current page ± 2 with ellipsis)
- ✅ Updated backend to handle pagination and filtering parameters

## Screenshots
### Before
- Only 6 cards shown initially
- Dropdown to "refetch" older weeks one at a time
- No year filtering capability

### After
- Full pagination controls with page navigation
- Configurable items per page
- Year filter buttons for quick filtering
- Shows "Page X of Y | Showing N of M weeks" for clarity

## Test Plan
- [x] Navigate through multiple pages using Previous/Next buttons
- [x] Click specific page numbers to jump to pages
- [x] Change page size from dropdown (10/20/50/100)
- [x] Filter by specific years using year buttons
- [x] Verify "All" button shows all weeks
- [x] Confirm pagination resets to page 1 when changing filters
- [x] Test with various numbers of weekly cards
- [x] Verify page info displays correctly

## Technical Details
- Backend route `/dashboard` now accepts query parameters:
  - `page`: Current page number (default: 1)
  - `per_page`: Items per page (default: 10, options: 10/20/50/100)
  - `year`: Year filter (optional)
- Frontend JavaScript `changePageSize()` function handles page size changes
- Jinja2 template calculates pagination display dynamically
- Year filtering maintains pagination state

🤖 Generated with [Claude Code](https://claude.ai/code)