### PR TITLE
Add version update check notification

### DIFF
--- a/src/api/routes/config.py
+++ b/src/api/routes/config.py
@@ -254,7 +254,7 @@ async def check_for_update():
         if "-" in current_version:
             # Handle versions like "1.0.5-2-g1234567"
             current_version = current_version.split("-")[0]
-        
+
         # Fetch latest release from GitHub
         async with httpx.AsyncClient() as client:
             response = await client.get(
@@ -262,17 +262,17 @@ async def check_for_update():
                 headers={"Accept": "application/vnd.github.v3+json"},
                 timeout=5.0,
             )
-            
+
             if response.status_code != 200:
                 logger.warning(f"GitHub API returned status {response.status_code}")
                 return {
                     "update_available": False,
                     "error": "Could not check for updates",
                 }
-            
+
             release_data = response.json()
             latest_version = release_data.get("tag_name", "").lstrip("v")
-            
+
             # Compare versions
             def parse_version(v):
                 """Parse semantic version string to tuple for comparison."""
@@ -281,17 +281,17 @@ async def check_for_update():
                     return tuple(int(p) for p in parts[:3])  # Major, minor, patch
                 except (ValueError, AttributeError):
                     return (0, 0, 0)
-            
+
             current_tuple = parse_version(current_version)
             latest_tuple = parse_version(latest_version)
-            
+
             update_available = latest_tuple > current_tuple
-            
+
             # Always link to releases page if update available
             changelog_url = None
             if update_available:
                 changelog_url = "https://github.com/iongpt/boxarr/releases"
-            
+
             return {
                 "update_available": update_available,
                 "current_version": __version__,
@@ -301,7 +301,7 @@ async def check_for_update():
                 "release_name": release_data.get("name"),
                 "published_at": release_data.get("published_at"),
             }
-            
+
     except httpx.TimeoutException:
         logger.warning("Timeout checking for updates")
         return {

--- a/src/api/routes/config.py
+++ b/src/api/routes/config.py
@@ -287,15 +287,10 @@ async def check_for_update():
             
             update_available = latest_tuple > current_tuple
             
-            # Generate changelog URL
+            # Always link to releases page if update available
             changelog_url = None
             if update_available:
-                # If we're on a tagged version, create a comparison link
-                if not ("-dev" in __version__ or "-dirty" in __version__):
-                    changelog_url = f"https://github.com/iongpt/boxarr/compare/v{current_version}...v{latest_version}"
-                else:
-                    # For dev versions, link to the release page
-                    changelog_url = release_data.get("html_url")
+                changelog_url = "https://github.com/iongpt/boxarr/releases"
             
             return {
                 "update_available": update_available,

--- a/src/web/static/js/app.js
+++ b/src/web/static/js/app.js
@@ -256,6 +256,43 @@ function reloadScheduler() {
     }
 
     /**
+     * Check for application updates
+     */
+    function checkForUpdates() {
+        fetch('/api/config/check-update')
+            .then(response => response.json())
+            .then(data => {
+                if (data.update_available) {
+                    const notification = document.getElementById('updateNotification');
+                    const updateText = document.getElementById('updateText');
+                    
+                    if (notification) {
+                        // Set the changelog URL
+                        if (data.changelog_url) {
+                            notification.href = data.changelog_url;
+                        } else if (data.release_url) {
+                            notification.href = data.release_url;
+                        }
+                        
+                        // Update the text to show version
+                        if (updateText) {
+                            updateText.textContent = `Update to v${data.latest_version}`;
+                        }
+                        
+                        // Show the notification
+                        notification.classList.add('show');
+                        
+                        // Log for debugging
+                        console.log(`Update available: v${data.current_version} → v${data.latest_version}`);
+                    }
+                }
+            })
+            .catch(error => {
+                console.error('Error checking for updates:', error);
+            });
+    }
+
+    /**
      * Show a temporary message to the user
      */
     function showMessage(message, type = 'info') {
@@ -1016,6 +1053,9 @@ function reloadScheduler() {
         // Check connection status
         checkConnection();
         setInterval(checkConnection, 30000);
+        
+        // Check for updates (only once on page load)
+        checkForUpdates();
         
         // Initialize page-specific features
         const path = window.location.pathname;

--- a/src/web/static/js/app.js
+++ b/src/web/static/js/app.js
@@ -274,9 +274,9 @@ function reloadScheduler() {
                             notification.href = data.release_url;
                         }
                         
-                        // Update the text to show version
+                        // Update the text
                         if (updateText) {
-                            updateText.textContent = `Update to v${data.latest_version}`;
+                            updateText.textContent = "See what's changed";
                         }
                         
                         // Show the notification

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -168,6 +168,37 @@
         .footer a:hover {
             text-decoration: underline;
         }
+        
+        /* Update notification styles */
+        .update-notification {
+            display: none;
+            background: linear-gradient(135deg, #667eea, #764ba2);
+            color: white;
+            padding: 0.25rem 0.75rem;
+            border-radius: 6px;
+            font-size: 0.85rem;
+            font-weight: 500;
+            margin-left: 0.5rem;
+            text-decoration: none;
+            transition: all 0.2s;
+        }
+        
+        .update-notification.show {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.25rem;
+        }
+        
+        .update-notification:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 2px 8px rgba(102, 126, 234, 0.3);
+            color: white;
+            text-decoration: none;
+        }
+        
+        .update-icon {
+            animation: pulse 2s infinite;
+        }
     </style>
     {% block styles %}{% endblock %}
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
@@ -178,6 +209,10 @@
             <div class="navbar-brand">
                 <h1>🎬 Boxarr</h1>
                 <span class="version-badge">v{{ version|default('0.4.1-dev-dirty') }}</span>
+                <a href="#" id="updateNotification" class="update-notification" target="_blank">
+                    <span class="update-icon">⬆️</span>
+                    <span id="updateText">Update available</span>
+                </a>
             </div>
             <div class="navbar-menu">
                 <a href="/dashboard" class="nav-link {% if request.path == '/dashboard' %}active{% endif %}">Dashboard</a>

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -211,7 +211,7 @@
                 <span class="version-badge">v{{ version|default('0.4.1-dev-dirty') }}</span>
                 <a href="#" id="updateNotification" class="update-notification" target="_blank">
                     <span class="update-icon">⬆️</span>
-                    <span id="updateText">Update available</span>
+                    <span id="updateText">See what's changed</span>
                 </a>
             </div>
             <div class="navbar-menu">


### PR DESCRIPTION
## Summary
Adds a small, unobtrusive version update check that notifies users when a new version is available on GitHub.

## Changes
- ✅ Added `/api/config/check-update` endpoint that checks GitHub releases
- ✅ Shows update notification badge next to version number when update available
- ✅ Links to GitHub releases page with text "See what's changed"
- ✅ Runs once on page load with minimal performance impact
- ✅ Graceful error handling if GitHub is unavailable

## Implementation Details
- **Backend**: New endpoint fetches latest release from GitHub API with 5s timeout
- **Frontend**: JavaScript checks for updates on page load
- **UI**: Small purple badge with upward arrow appears when update available
- **Link**: Goes to https://github.com/iongpt/boxarr/releases to see all changes

## Why This Helps
Users can easily see when updates are available without having to manually check GitHub. The notification is subtle and non-intrusive, appearing only when relevant.

## Test Plan
- [x] Verify update notification appears when running older version
- [x] Verify clicking notification opens releases page in new tab
- [x] Verify no notification when running latest version
- [x] Verify graceful handling when GitHub API is unavailable
- [x] Verify correct text: "See what's changed"

🤖 Generated with [Claude Code](https://claude.ai/code)