### PR TITLE
[FEATURE] Add URL base support for reverse proxy configurations

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -49,7 +49,7 @@ def create_app(scheduler: Optional[BoxarrScheduler] = None) -> FastAPI:
     # Add ProxyHeadersMiddleware to handle reverse proxy headers
     # Note: Remove trusted_hosts parameter for better security
     # Only add specific hosts if needed: trusted_hosts=["proxy.example.com"]
-    app.add_middleware(ProxyHeadersMiddleware)
+    app.add_middleware(ProxyHeadersMiddleware)  # type: ignore[arg-type]
 
     # Add CORS middleware for local network access
     app.add_middleware(

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -47,7 +47,9 @@ def create_app(scheduler: Optional[BoxarrScheduler] = None) -> FastAPI:
     )
 
     # Add ProxyHeadersMiddleware to handle reverse proxy headers
-    app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=["*"])
+    # Note: Remove trusted_hosts parameter for better security
+    # Only add specific hosts if needed: trusted_hosts=["proxy.example.com"]
+    app.add_middleware(ProxyHeadersMiddleware)
     
     # Add CORS middleware for local network access
     app.add_middleware(

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -36,7 +36,7 @@ def create_app(scheduler: Optional[BoxarrScheduler] = None) -> FastAPI:
     # Prepare root_path from settings
     base = settings.boxarr_url_base
     root_path = f"/{base}" if base else ""
-    
+
     app = FastAPI(
         title="Boxarr",
         description="Box Office Tracking for Radarr - A local media management tool",
@@ -50,7 +50,7 @@ def create_app(scheduler: Optional[BoxarrScheduler] = None) -> FastAPI:
     # Note: Remove trusted_hosts parameter for better security
     # Only add specific hosts if needed: trusted_hosts=["proxy.example.com"]
     app.add_middleware(ProxyHeadersMiddleware)
-    
+
     # Add CORS middleware for local network access
     app.add_middleware(
         CORSMiddleware,

--- a/src/api/routes/web.py
+++ b/src/api/routes/web.py
@@ -25,7 +25,7 @@ templates = Jinja2Templates(directory="src/web/templates")
 # Helper function for URL generation in templates
 def url_for(request: Request, path: str) -> str:
     """Generate URL with proper base path handling."""
-    root_path = request.scope.get("root_path", "")
+    root_path = str(request.scope.get("root_path", ""))
     if not path.startswith("/"):
         path = "/" + path
     return root_path + path

--- a/src/api/routes/web.py
+++ b/src/api/routes/web.py
@@ -21,16 +21,18 @@ router = APIRouter(tags=["web"])
 # Template directory
 templates = Jinja2Templates(directory="src/web/templates")
 
+
 # Helper function for URL generation in templates
 def url_for(request: Request, path: str) -> str:
     """Generate URL with proper base path handling."""
-    root_path = request.scope.get('root_path', '')
-    if not path.startswith('/'):
-        path = '/' + path
+    root_path = request.scope.get("root_path", "")
+    if not path.startswith("/"):
+        path = "/" + path
     return root_path + path
 
+
 # Register the helper as a Jinja2 global
-templates.env.globals['url_for'] = url_for
+templates.env.globals["url_for"] = url_for
 
 
 class WeekInfo(BaseModel):
@@ -59,11 +61,11 @@ async def home_page(request: Request):
     """Serve the home page (dashboard or setup)."""
     # Check if Radarr is configured
     if not settings.is_configured:
-        base = request.scope.get('root_path', '')
+        base = request.scope.get("root_path", "")
         return RedirectResponse(url=f"{base}/setup")
 
     # Always redirect to dashboard when configured
-    base = request.scope.get('root_path', '')
+    base = request.scope.get("root_path", "")
     return RedirectResponse(url=f"{base}/dashboard")
 
 
@@ -72,7 +74,7 @@ async def dashboard_page(request: Request):
     """Serve the dashboard page."""
     # Check if configured - if not, redirect to setup
     if not settings.is_configured:
-        base = request.scope.get('root_path', '')
+        base = request.scope.get("root_path", "")
         return RedirectResponse(url=f"{base}/setup")
 
     # Get query parameters for pagination and filtering
@@ -484,7 +486,7 @@ async def get_widget(request: Request):
 
         # Build the base URL with correct scheme, host, and base path
         # request.base_url already includes the root_path from FastAPI
-        full_url = str(request.base_url).rstrip('/') + '/'
+        full_url = str(request.base_url).rstrip("/") + "/"
 
         # Simple widget HTML
         html = f"""

--- a/src/api/routes/web.py
+++ b/src/api/routes/web.py
@@ -21,6 +21,17 @@ router = APIRouter(tags=["web"])
 # Template directory
 templates = Jinja2Templates(directory="src/web/templates")
 
+# Helper function for URL generation in templates
+def url_for(request: Request, path: str) -> str:
+    """Generate URL with proper base path handling."""
+    root_path = request.scope.get('root_path', '')
+    if not path.startswith('/'):
+        path = '/' + path
+    return root_path + path
+
+# Register the helper as a Jinja2 global
+templates.env.globals['url_for'] = url_for
+
 
 class WeekInfo(BaseModel):
     """Week information model."""

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -79,6 +79,10 @@ class Settings(BaseSettings):
     boxarr_api_port: int = Field(
         default=8889, ge=1, le=65535, description="API server port"
     )
+    boxarr_url_base: str = Field(
+        default="",
+        description="URL base path for reverse proxy (e.g., 'boxarr' for /boxarr/)",
+    )
 
     # Scheduler Configuration
     boxarr_scheduler_enabled: bool = Field(
@@ -166,6 +170,11 @@ class Settings(BaseSettings):
         default="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
         description="Log format string",
     )
+
+    @validator("boxarr_url_base")
+    def normalize_url_base(cls, v: str) -> str:
+        """Normalize URL base by stripping leading/trailing slashes."""
+        return v.strip("/") if v else ""
 
     @validator("radarr_api_key")
     def validate_api_key(cls, v: str) -> str:

--- a/src/web/static/js/app.js
+++ b/src/web/static/js/app.js
@@ -23,6 +23,32 @@ function apiUrl(endpoint) {
     return makeUrl('/api' + endpoint);
 }
 
+// Helper to check if current path matches a given path (handling base path)
+function isCurrentPath(targetPath) {
+    const currentPath = window.location.pathname;
+    const expectedPath = makeUrl(targetPath);
+    return currentPath === expectedPath;
+}
+
+// Helper to get path without base
+function getPathWithoutBase() {
+    const currentPath = window.location.pathname;
+    if (BASE_PATH && currentPath.startsWith(BASE_PATH)) {
+        return currentPath.substring(BASE_PATH.length);
+    }
+    return currentPath;
+}
+
+// Safe URL construction that prevents double-prefixing
+function safeUrl(path) {
+    // If path is already absolute and contains base path, return as-is
+    if (BASE_PATH && path.startsWith(BASE_PATH)) {
+        return path;
+    }
+    // Otherwise use makeUrl to add base path
+    return makeUrl(path);
+}
+
 // Scheduler Debug Functions (Global scope for onclick handlers)
 function toggleSchedulerDebug() {
     const content = document.getElementById('schedulerDebugContent');
@@ -513,7 +539,7 @@ function reloadScheduler() {
                 if (progressMessage) progressMessage.textContent = '✅ Historical week fetched successfully!';
                 addLogEntry('Update completed!', 'success');
                 if (progressFooter) progressFooter.style.display = 'block';
-                setTimeout(() => window.location.href = makeUrl(selectedHistoricalWeekUrl), 2000);
+                setTimeout(() => window.location.href = safeUrl(selectedHistoricalWeekUrl), 2000);
             } else {
                 const errorMsg = data.message || data.error || 'Unknown error occurred';
                 if (progressMessage) progressMessage.textContent = '❌ Fetch failed';
@@ -1078,9 +1104,9 @@ function reloadScheduler() {
         checkForUpdates();
         
         // Initialize page-specific features
-        const path = window.location.pathname;
+        const path = getPathWithoutBase();
         
-        if (path.includes('W') && path !== '/dashboard') {
+        if (path.includes('W') && !isCurrentPath('/dashboard')) {
             // Weekly page - start status updates
             updateMovieStatuses();
             // More frequent updates initially (every 5 seconds for first minute)
@@ -1097,7 +1123,7 @@ function reloadScheduler() {
         }
         
         // Setup page specific initialization
-        if (path === '/setup') {
+        if (isCurrentPath('/setup')) {
             const radarrUrl = document.getElementById('radarrUrl');
             const radarrApiKey = document.getElementById('radarrApiKey');
             const saveBtn = document.getElementById('saveBtn');

--- a/src/web/static/js/app.js
+++ b/src/web/static/js/app.js
@@ -3,6 +3,26 @@
  * Unified JavaScript for all pages
  */
 
+// Get base path from injected variable (set in base.html)
+const BASE_PATH = window.BOXARR_BASE_PATH || '';
+
+// URL helper functions
+function makeUrl(path) {
+    // Ensure path starts with /
+    if (!path.startsWith('/')) {
+        path = '/' + path;
+    }
+    return BASE_PATH + path;
+}
+
+function apiUrl(endpoint) {
+    // Ensure endpoint starts with /
+    if (!endpoint.startsWith('/')) {
+        endpoint = '/' + endpoint;
+    }
+    return makeUrl('/api' + endpoint);
+}
+
 // Scheduler Debug Functions (Global scope for onclick handlers)
 function toggleSchedulerDebug() {
     const content = document.getElementById('schedulerDebugContent');
@@ -83,7 +103,7 @@ function updateGenreMode() {
 }
 
 function refreshSchedulerStatus() {
-    fetch('/api/scheduler/status')
+    fetch(apiUrl('/scheduler/status'))
         .then(response => response.json())
         .then(data => {
             // Update service status
@@ -167,7 +187,7 @@ function triggerScheduler() {
     btn.disabled = true;
     btn.textContent = 'Triggering...';
     
-    fetch('/api/scheduler/trigger', { method: 'POST' })
+    fetch(apiUrl('/scheduler/trigger'), { method: 'POST' })
         .then(response => response.json())
         .then(data => {
             if (data.success) {
@@ -193,7 +213,7 @@ function reloadScheduler() {
     btn.disabled = true;
     btn.textContent = 'Reloading...';
     
-    fetch('/api/scheduler/reload', { method: 'POST' })
+    fetch(apiUrl('/scheduler/reload'), { method: 'POST' })
         .then(response => response.json())
         .then(data => {
             if (data.success) {
@@ -234,7 +254,7 @@ function reloadScheduler() {
         // Skip if elements don't exist (e.g., on setup page)
         if (!statusDot || !statusText) return;
         
-        fetch('/api/health')
+        fetch(apiUrl('/health'))
             .then(response => {
                 if (response.ok) {
                     statusDot.classList.add('connected');
@@ -259,7 +279,7 @@ function reloadScheduler() {
      * Check for application updates
      */
     function checkForUpdates() {
-        fetch('/api/config/check-update')
+        fetch(apiUrl('/config/check-update'))
             .then(response => response.json())
             .then(data => {
                 if (data.update_available) {
@@ -356,7 +376,7 @@ function reloadScheduler() {
         
         addLogEntry('Starting box office update...');
         
-        fetch('/api/scheduler/trigger', { method: 'POST' })
+        fetch(apiUrl('/scheduler/trigger'), { method: 'POST' })
             .then(response => {
                 addLogEntry('Received response from server');
                 return response.json();
@@ -472,7 +492,7 @@ function reloadScheduler() {
         
         addLogEntry(`Starting historical data fetch for ${selectedHistoricalWeekText}`);
         
-        fetch('/api/scheduler/update-week', {
+        fetch(apiUrl('/scheduler/update-week'), {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ 
@@ -493,7 +513,7 @@ function reloadScheduler() {
                 if (progressMessage) progressMessage.textContent = '✅ Historical week fetched successfully!';
                 addLogEntry('Update completed!', 'success');
                 if (progressFooter) progressFooter.style.display = 'block';
-                setTimeout(() => window.location.href = selectedHistoricalWeekUrl, 2000);
+                setTimeout(() => window.location.href = makeUrl(selectedHistoricalWeekUrl), 2000);
             } else {
                 const errorMsg = data.message || data.error || 'Unknown error occurred';
                 if (progressMessage) progressMessage.textContent = '❌ Fetch failed';
@@ -571,7 +591,7 @@ function reloadScheduler() {
         
         addLogEntry(`Starting historical data fetch for Week ${week}, ${year}`);
         
-        fetch('/api/scheduler/update-week', {
+        fetch(apiUrl('/scheduler/update-week'), {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ 
@@ -592,7 +612,7 @@ function reloadScheduler() {
                 if (progressMessage) progressMessage.textContent = '✅ Historical week updated successfully!';
                 addLogEntry('Update completed!', 'success');
                 if (progressFooter) progressFooter.style.display = 'block';
-                setTimeout(() => window.location.href = `/${year}W${String(week).padStart(2, '0')}`, 2000);
+                setTimeout(() => window.location.href = makeUrl(`/${year}W${String(week).padStart(2, '0')}`), 2000);
             } else {
                 const errorMsg = data.message || data.error || 'Unknown error occurred';
                 if (progressMessage) progressMessage.textContent = '❌ Update failed';
@@ -627,7 +647,7 @@ function reloadScheduler() {
 
     window.deleteWeek = function(year, week) {
         if (confirm(`Are you sure you want to delete Week ${week}, ${year}?`)) {
-            fetch(`/api/weeks/${year}/W${week}/delete`, { method: 'DELETE' })
+            fetch(apiUrl(`/weeks/${year}/W${week}/delete`), { method: 'DELETE' })
                 .then(response => response.json())
                 .then(data => {
                     if (data.success) {
@@ -647,7 +667,7 @@ function reloadScheduler() {
         const urlParams = new URLSearchParams(window.location.search);
         urlParams.set('per_page', newSize);
         urlParams.set('page', '1'); // Reset to first page when changing page size
-        window.location.href = `/dashboard?${urlParams.toString()}`;
+        window.location.href = makeUrl(`/dashboard?${urlParams.toString()}`);
     };
 
     // ==========================================
@@ -662,7 +682,7 @@ function reloadScheduler() {
         
         if (movieIds.length === 0) return;
         
-        fetch('/api/movies/status', {
+        fetch(apiUrl('/movies/status'), {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ movie_ids: movieIds })
@@ -716,7 +736,7 @@ function reloadScheduler() {
                 buttonElement.style.opacity = '0.7';
             }
             
-            fetch('/api/movies/add', {
+            fetch(apiUrl('/movies/add'), {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ title, year })
@@ -773,7 +793,7 @@ function reloadScheduler() {
                 buttonElement.textContent = 'Processing...';
             }
             
-            fetch(`/api/movies/${movieId}/upgrade`, {
+            fetch(apiUrl(`/movies/${movieId}/upgrade`), {
                 method: 'POST'
             })
             .then(response => response.json())
@@ -831,7 +851,7 @@ function reloadScheduler() {
         if (testButton) testButton.textContent = 'Testing...';
         if (testSpinner) testSpinner.style.display = 'inline-block';
         
-        fetch('/api/config/test', {
+        fetch(apiUrl('/config/test'), {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ url, api_key: apiKey })
@@ -1002,7 +1022,7 @@ function reloadScheduler() {
         
         showMessage('Saving configuration...', 'info');
         
-        fetch('/api/config/save', {
+        fetch(apiUrl('/config/save'), {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(config)
@@ -1012,7 +1032,7 @@ function reloadScheduler() {
             if (data.success) {
                 showMessage('✓ Configuration saved successfully! Redirecting...', 'success');
                 setTimeout(() => {
-                    window.location.href = '/dashboard';
+                    window.location.href = makeUrl('/dashboard');
                 }, 1500);
             } else {
                 showMessage('Failed to save: ' + (data.error || 'Unknown error'), 'error');

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -219,8 +219,8 @@
                 </a>
             </div>
             <div class="navbar-menu">
-                <a href="{{ request.scope.get('root_path', '') }}/dashboard" class="nav-link {% if request.path == '/dashboard' %}active{% endif %}">Dashboard</a>
-                <a href="{{ request.scope.get('root_path', '') }}/setup" class="nav-link {% if request.path == '/setup' %}active{% endif %}">Settings</a>
+                <a href="{{ request.scope.get('root_path', '') }}/dashboard" class="nav-link {% if request.path.endswith('/dashboard') %}active{% endif %}">Dashboard</a>
+                <a href="{{ request.scope.get('root_path', '') }}/setup" class="nav-link {% if request.path.endswith('/setup') %}active{% endif %}">Settings</a>
                 <!-- <a href="/docs" class="nav-link" target="_blank">API Docs</a> -->
                 <div class="connection-status" id="connectionStatus">
                     <span class="status-dot" id="statusDot"></span>

--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -204,6 +204,10 @@
     <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
 </head>
 <body>
+    <script>
+        // Inject base path for JavaScript usage
+        window.BOXARR_BASE_PATH = "{{ request.scope.get('root_path', '') }}";
+    </script>
     <nav class="navbar">
         <div class="navbar-container">
             <div class="navbar-brand">
@@ -215,8 +219,8 @@
                 </a>
             </div>
             <div class="navbar-menu">
-                <a href="/dashboard" class="nav-link {% if request.path == '/dashboard' %}active{% endif %}">Dashboard</a>
-                <a href="/setup" class="nav-link {% if request.path == '/setup' %}active{% endif %}">Settings</a>
+                <a href="{{ request.scope.get('root_path', '') }}/dashboard" class="nav-link {% if request.path == '/dashboard' %}active{% endif %}">Dashboard</a>
+                <a href="{{ request.scope.get('root_path', '') }}/setup" class="nav-link {% if request.path == '/setup' %}active{% endif %}">Settings</a>
                 <!-- <a href="/docs" class="nav-link" target="_blank">API Docs</a> -->
                 <div class="connection-status" id="connectionStatus">
                     <span class="status-dot" id="statusDot"></span>
@@ -236,7 +240,7 @@
         </div>
     </footer>
 
-    <script src="/static/js/app.js?v=2"></script>
+    <script src="{{ request.scope.get('root_path', '') }}/static/js/app.js?v=2"></script>
     {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/src/web/templates/dashboard.html
+++ b/src/web/templates/dashboard.html
@@ -675,7 +675,7 @@
             </button>
             
             {% if recent_weeks %}
-            <a href="/{{ recent_weeks[0].year }}W{{ '%02d'|format(recent_weeks[0].week) }}" class="action-btn primary">
+            <a href="{{ request.scope.get('root_path', '') }}/{{ recent_weeks[0].year }}W{{ '%02d'|format(recent_weeks[0].week) }}" class="action-btn primary">
                 <span class="btn-icon">👁️</span> View Last Week
             </a>
             {% endif %}
@@ -688,10 +688,10 @@
         <div class="filter-controls">
             <div class="year-filters">
                 <span class="year-filter-label">Filter by year:</span>
-                <a href="/dashboard?page=1&per_page={{ per_page }}" 
+                <a href="{{ request.scope.get('root_path', '') }}/dashboard?page=1&per_page={{ per_page }}" 
                    class="year-btn {% if not year_filter %}active{% endif %}">All</a>
                 {% for year in available_years %}
-                <a href="/dashboard?year={{ year }}&page=1&per_page={{ per_page }}" 
+                <a href="{{ request.scope.get('root_path', '') }}/dashboard?year={{ year }}&page=1&per_page={{ per_page }}" 
                    class="year-btn {% if year_filter == year %}active{% endif %}">{{ year }}</a>
                 {% endfor %}
             </div>
@@ -745,7 +745,7 @@
                     </div>
                     
                     <div class="report-actions">
-                        <a href="/{{ week.year }}W{{ '%02d'|format(week.week) }}" class="report-btn view">View</a>
+                        <a href="{{ request.scope.get('root_path', '') }}/{{ week.year }}W{{ '%02d'|format(week.week) }}" class="report-btn view">View</a>
                         <button class="report-btn delete" onclick="deleteWeek('{{ week.year }}', '{{ '%02d'|format(week.week) }}')">Delete</button>
                     </div>
                 </div>
@@ -758,7 +758,7 @@
                 <div class="pagination">
                     <!-- Previous button -->
                     {% if current_page > 1 %}
-                    <a href="/dashboard?page={{ current_page - 1 }}&per_page={{ per_page }}{% if year_filter %}&year={{ year_filter }}{% endif %}" 
+                    <a href="{{ request.scope.get('root_path', '') }}/dashboard?page={{ current_page - 1 }}&per_page={{ per_page }}{% if year_filter %}&year={{ year_filter }}{% endif %}" 
                        class="page-link">← Previous</a>
                     {% else %}
                     <span class="page-link disabled">← Previous</span>
@@ -771,7 +771,7 @@
                     {% if end_page > total_pages %}{% set end_page = total_pages %}{% endif %}
                     
                     {% if start_page > 1 %}
-                    <a href="/dashboard?page=1&per_page={{ per_page }}{% if year_filter %}&year={{ year_filter }}{% endif %}" 
+                    <a href="{{ request.scope.get('root_path', '') }}/dashboard?page=1&per_page={{ per_page }}{% if year_filter %}&year={{ year_filter }}{% endif %}" 
                        class="page-link">1</a>
                     {% if start_page > 2 %}
                     <span class="page-link disabled">...</span>
@@ -782,7 +782,7 @@
                     {% if page_num == current_page %}
                     <span class="page-link active">{{ page_num }}</span>
                     {% else %}
-                    <a href="/dashboard?page={{ page_num }}&per_page={{ per_page }}{% if year_filter %}&year={{ year_filter }}{% endif %}" 
+                    <a href="{{ request.scope.get('root_path', '') }}/dashboard?page={{ page_num }}&per_page={{ per_page }}{% if year_filter %}&year={{ year_filter }}{% endif %}" 
                        class="page-link">{{ page_num }}</a>
                     {% endif %}
                     {% endfor %}
@@ -791,13 +791,13 @@
                     {% if end_page < total_pages - 1 %}
                     <span class="page-link disabled">...</span>
                     {% endif %}
-                    <a href="/dashboard?page={{ total_pages }}&per_page={{ per_page }}{% if year_filter %}&year={{ year_filter }}{% endif %}" 
+                    <a href="{{ request.scope.get('root_path', '') }}/dashboard?page={{ total_pages }}&per_page={{ per_page }}{% if year_filter %}&year={{ year_filter }}{% endif %}" 
                        class="page-link">{{ total_pages }}</a>
                     {% endif %}
                     
                     <!-- Next button -->
                     {% if current_page < total_pages %}
-                    <a href="/dashboard?page={{ current_page + 1 }}&per_page={{ per_page }}{% if year_filter %}&year={{ year_filter }}{% endif %}" 
+                    <a href="{{ request.scope.get('root_path', '') }}/dashboard?page={{ current_page + 1 }}&per_page={{ per_page }}{% if year_filter %}&year={{ year_filter }}{% endif %}" 
                        class="page-link">Next →</a>
                     {% else %}
                     <span class="page-link disabled">Next →</span>
@@ -864,7 +864,7 @@
                     {% endif %}
                     
                     <p style="margin-top: 1rem; font-size: 0.85rem; color: var(--text-primary);">
-                        💡 <strong>Note:</strong> This behavior applies to all historical fetches. You can change these settings in <a href="/setup" style="color: var(--primary-color); text-decoration: underline;">Settings</a>.
+                        💡 <strong>Note:</strong> This behavior applies to all historical fetches. You can change these settings in <a href="{{ request.scope.get('root_path', '') }}/setup" style="color: var(--primary-color); text-decoration: underline;">Settings</a>.
                     </p>
                 </div>
             </div>
@@ -907,7 +907,7 @@
             
             <div style="padding: 0.75rem; background: rgba(var(--info-rgb, 59, 130, 246), 0.1); border-radius: 8px; border: 1px solid rgba(var(--info-rgb, 59, 130, 246), 0.2);">
                 <p style="font-size: 0.85rem; color: var(--text-primary); margin: 0;">
-                    💡 <strong>Tip:</strong> To change auto-add behavior or filters, visit <a href="/setup" style="color: var(--primary-color); text-decoration: underline;">Settings</a>.
+                    💡 <strong>Tip:</strong> To change auto-add behavior or filters, visit <a href="{{ request.scope.get('root_path', '') }}/setup" style="color: var(--primary-color); text-decoration: underline;">Settings</a>.
                 </p>
             </div>
         </div>

--- a/src/web/templates/setup.html
+++ b/src/web/templates/setup.html
@@ -7,6 +7,10 @@
     <link rel="stylesheet" href="{{ request.scope.get('root_path', '') }}/static/css/style.css">
 </head>
 <body class="setup-page">
+    <script>
+        // Inject base path for JavaScript usage
+        window.BOXARR_BASE_PATH = "{{ request.scope.get('root_path', '') }}";
+    </script>
     <div class="setup-container">
         <div class="setup-header">
             <h1 class="setup-title">🎬 Welcome to Boxarr!</h1>

--- a/src/web/templates/setup.html
+++ b/src/web/templates/setup.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Boxarr Setup{% endblock %}</title>
-    <link rel="stylesheet" href="/static/css/style.css">
+    <link rel="stylesheet" href="{{ request.scope.get('root_path', '') }}/static/css/style.css">
 </head>
 <body class="setup-page">
     <div class="setup-container">
@@ -286,10 +286,10 @@
 
             <div class="button-row">
                 {% if is_configured %}
-                <a href="/" class="btn btn-secondary">← Back to Dashboard</a>
+                <a href="{{ request.scope.get('root_path', '') }}/" class="btn btn-secondary">← Back to Dashboard</a>
                 {% else %}
                 <div id="navigationSection" style="display: none;">
-                    <a href="/" class="btn btn-secondary">← Back to Dashboard</a>
+                    <a href="{{ request.scope.get('root_path', '') }}/" class="btn btn-secondary">← Back to Dashboard</a>
                 </div>
                 {% endif %}
                 
@@ -303,6 +303,6 @@
         </form>
     </div>
 
-<script src="/static/js/app.js?v=2"></script>
+<script src="{{ request.scope.get('root_path', '') }}/static/js/app.js?v=2"></script>
 </body>
 </html>

--- a/src/web/templates/weekly.html
+++ b/src/web/templates/weekly.html
@@ -370,13 +370,13 @@
         <!-- Navigation Controls -->
         <div class="nav-controls">
             {% if previous_week %}
-            <a href="/{{ previous_week }}" class="nav-btn">← Previous</a>
+            <a href="{{ request.scope.get('root_path', '') }}/{{ previous_week }}" class="nav-btn">← Previous</a>
             {% endif %}
             
-            <a href="/dashboard" class="nav-btn">📊 Dashboard</a>
+            <a href="{{ request.scope.get('root_path', '') }}/dashboard" class="nav-btn">📊 Dashboard</a>
             
             {% if next_week %}
-            <a href="/{{ next_week }}" class="nav-btn">Next →</a>
+            <a href="{{ request.scope.get('root_path', '') }}/{{ next_week }}" class="nav-btn">Next →</a>
             {% endif %}
         </div>
     </div>

--- a/tests/integration/test_url_base.py
+++ b/tests/integration/test_url_base.py
@@ -12,29 +12,29 @@ def test_empty_url_base(monkeypatch):
     # Mock unconfigured state (no API key)
     monkeypatch.setattr("src.utils.config.settings.radarr_api_key", "")
     monkeypatch.setattr("src.api.routes.web.settings.radarr_api_key", "")
-    
+
     # Create app with empty url_base
     app = create_app()
     client = TestClient(app)
-    
+
     # Test health endpoint at root
     response = client.get("/api/health")
     assert response.status_code == 200
     assert response.json()["status"] == "healthy"
-    
+
     # Test redirect from root to setup when unconfigured
     response = client.get("/", follow_redirects=False)
     assert response.status_code == 307
     assert response.headers["location"] == "/setup"
-    
+
     # Test with configured state
     monkeypatch.setattr("src.utils.config.settings.radarr_api_key", "test_key")
     monkeypatch.setattr("src.api.routes.web.settings.radarr_api_key", "test_key")
-    
+
     # Recreate app with configuration
     app = create_app()
     client = TestClient(app)
-    
+
     # Now should redirect to dashboard
     response = client.get("/", follow_redirects=False)
     assert response.status_code == 307
@@ -48,38 +48,38 @@ def test_url_base_boxarr(monkeypatch):
     monkeypatch.setattr("src.utils.config.settings.radarr_api_key", "")
     monkeypatch.setattr("src.api.app.settings.boxarr_url_base", "boxarr")
     monkeypatch.setattr("src.api.routes.web.settings.radarr_api_key", "")
-    
+
     # Create app with url_base
     app = create_app()
     client = TestClient(app)
-    
+
     # Test health endpoint with base path
     response = client.get("/boxarr/api/health")
     assert response.status_code == 200
     assert response.json()["status"] == "healthy"
-    
+
     # Test redirect from root to setup with base path (unconfigured)
     response = client.get("/boxarr/", follow_redirects=False)
     assert response.status_code == 307
     assert response.headers["location"] == "/boxarr/setup"
-    
+
     # Test with configured state
     monkeypatch.setattr("src.utils.config.settings.radarr_api_key", "test_key")
     monkeypatch.setattr("src.api.routes.web.settings.radarr_api_key", "test_key")
-    
+
     # Recreate app
     app = create_app()
     client = TestClient(app)
-    
+
     # Now should redirect to dashboard
     response = client.get("/boxarr/", follow_redirects=False)
     assert response.status_code == 307
     assert response.headers["location"] == "/boxarr/dashboard"
-    
+
     # Test widget endpoint includes correct URL
     response = client.get("/boxarr/api/widget")
     assert response.status_code == 200
-    assert "href=\"http://testserver/boxarr/\"" in response.text
+    assert 'href="http://testserver/boxarr/"' in response.text
 
 
 def test_url_base_nested_path(monkeypatch):
@@ -89,16 +89,16 @@ def test_url_base_nested_path(monkeypatch):
     monkeypatch.setattr("src.utils.config.settings.radarr_api_key", "test_key")
     monkeypatch.setattr("src.api.app.settings.boxarr_url_base", "apps/boxarr")
     monkeypatch.setattr("src.api.routes.web.settings.radarr_api_key", "test_key")
-    
+
     # Create app with nested url_base
     app = create_app()
     client = TestClient(app)
-    
+
     # Test health endpoint with nested base path
     response = client.get("/apps/boxarr/api/health")
     assert response.status_code == 200
     assert response.json()["status"] == "healthy"
-    
+
     # Test redirect with nested base path (configured, goes to dashboard)
     response = client.get("/apps/boxarr/", follow_redirects=False)
     assert response.status_code == 307
@@ -114,7 +114,7 @@ def test_url_base_normalization(monkeypatch):
         ("//boxarr//", "boxarr"),
         ("/apps/boxarr/", "apps/boxarr"),
     ]
-    
+
     for input_base, expected_normalized in test_cases:
         # Test normalization in settings validator
         settings = Settings(boxarr_url_base=input_base)
@@ -128,14 +128,14 @@ def test_javascript_base_path_injection(monkeypatch):
     monkeypatch.setattr("src.utils.config.settings.radarr_api_key", "")
     monkeypatch.setattr("src.api.app.settings.boxarr_url_base", "boxarr")
     monkeypatch.setattr("src.api.routes.web.settings.radarr_api_key", "")
-    
+
     app = create_app()
     client = TestClient(app)
-    
+
     # Request setup page (since we're unconfigured)
     response = client.get("/boxarr/setup")
-    
+
     # Check that base path is injected into JavaScript
     assert response.status_code == 200
     assert "window.BOXARR_BASE_PATH" in response.text
-    assert '/boxarr' in response.text  # Should see the base path somewhere
+    assert "/boxarr" in response.text  # Should see the base path somewhere

--- a/tests/integration/test_url_base.py
+++ b/tests/integration/test_url_base.py
@@ -1,0 +1,105 @@
+"""Integration tests for URL base support."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api.app import create_app
+from src.utils.config import Settings
+
+
+def test_empty_url_base():
+    """Test that application works with empty url_base (backward compatibility)."""
+    # Create app with empty url_base
+    app = create_app()
+    client = TestClient(app)
+    
+    # Test health endpoint at root
+    response = client.get("/api/health")
+    assert response.status_code == 200
+    assert response.json()["status"] == "healthy"
+    
+    # Test redirect from root to dashboard
+    response = client.get("/", follow_redirects=False)
+    assert response.status_code == 307
+    assert response.headers["location"] == "/dashboard"
+
+
+def test_url_base_boxarr(monkeypatch):
+    """Test that application works with url_base set to 'boxarr'."""
+    # Mock settings with url_base
+    monkeypatch.setattr("src.utils.config.settings.boxarr_url_base", "boxarr")
+    monkeypatch.setattr("src.api.app.settings.boxarr_url_base", "boxarr")
+    
+    # Create app with url_base
+    app = create_app()
+    client = TestClient(app)
+    
+    # Test health endpoint with base path
+    response = client.get("/boxarr/api/health")
+    assert response.status_code == 200
+    assert response.json()["status"] == "healthy"
+    
+    # Test redirect from root to dashboard with base path
+    response = client.get("/boxarr/", follow_redirects=False)
+    assert response.status_code == 307
+    assert response.headers["location"] == "/boxarr/dashboard"
+    
+    # Test widget endpoint includes correct URL
+    response = client.get("/boxarr/api/widget")
+    assert response.status_code == 200
+    assert "href=\"http://testserver/boxarr/\"" in response.text
+
+
+def test_url_base_nested_path(monkeypatch):
+    """Test that application works with nested url_base like 'apps/boxarr'."""
+    # Mock settings with nested url_base
+    monkeypatch.setattr("src.utils.config.settings.boxarr_url_base", "apps/boxarr")
+    monkeypatch.setattr("src.api.app.settings.boxarr_url_base", "apps/boxarr")
+    
+    # Create app with nested url_base
+    app = create_app()
+    client = TestClient(app)
+    
+    # Test health endpoint with nested base path
+    response = client.get("/apps/boxarr/api/health")
+    assert response.status_code == 200
+    assert response.json()["status"] == "healthy"
+    
+    # Test redirect with nested base path
+    response = client.get("/apps/boxarr/", follow_redirects=False)
+    assert response.status_code == 307
+    assert response.headers["location"] == "/apps/boxarr/dashboard"
+
+
+def test_url_base_normalization(monkeypatch):
+    """Test that url_base is normalized correctly (strips slashes)."""
+    test_cases = [
+        ("/boxarr/", "boxarr"),
+        ("boxarr/", "boxarr"),
+        ("/boxarr", "boxarr"),
+        ("//boxarr//", "boxarr"),
+        ("/apps/boxarr/", "apps/boxarr"),
+    ]
+    
+    for input_base, expected_normalized in test_cases:
+        # Test normalization in settings validator
+        settings = Settings(boxarr_url_base=input_base)
+        assert settings.boxarr_url_base == expected_normalized
+
+
+def test_javascript_base_path_injection(monkeypatch):
+    """Test that base path is correctly injected for JavaScript."""
+    # Mock settings with url_base
+    monkeypatch.setattr("src.utils.config.settings.boxarr_url_base", "boxarr")
+    monkeypatch.setattr("src.api.app.settings.boxarr_url_base", "boxarr")
+    
+    app = create_app()
+    client = TestClient(app)
+    
+    # Request dashboard page to check JavaScript injection
+    response = client.get("/boxarr/dashboard")
+    
+    # Check that base path is injected into JavaScript
+    if response.status_code == 200:  # Only if dashboard loads
+        assert "window.BOXARR_BASE_PATH" in response.text
+        # The exact value depends on template rendering

--- a/tests/integration/test_url_base.py
+++ b/tests/integration/test_url_base.py
@@ -7,8 +7,12 @@ from src.api.app import create_app
 from src.utils.config import Settings
 
 
-def test_empty_url_base():
+def test_empty_url_base(monkeypatch):
     """Test that application works with empty url_base (backward compatibility)."""
+    # Mock unconfigured state (no API key)
+    monkeypatch.setattr("src.utils.config.settings.radarr_api_key", "")
+    monkeypatch.setattr("src.api.routes.web.settings.radarr_api_key", "")
+    
     # Create app with empty url_base
     app = create_app()
     client = TestClient(app)
@@ -18,7 +22,20 @@ def test_empty_url_base():
     assert response.status_code == 200
     assert response.json()["status"] == "healthy"
     
-    # Test redirect from root to dashboard
+    # Test redirect from root to setup when unconfigured
+    response = client.get("/", follow_redirects=False)
+    assert response.status_code == 307
+    assert response.headers["location"] == "/setup"
+    
+    # Test with configured state
+    monkeypatch.setattr("src.utils.config.settings.radarr_api_key", "test_key")
+    monkeypatch.setattr("src.api.routes.web.settings.radarr_api_key", "test_key")
+    
+    # Recreate app with configuration
+    app = create_app()
+    client = TestClient(app)
+    
+    # Now should redirect to dashboard
     response = client.get("/", follow_redirects=False)
     assert response.status_code == 307
     assert response.headers["location"] == "/dashboard"
@@ -26,9 +43,11 @@ def test_empty_url_base():
 
 def test_url_base_boxarr(monkeypatch):
     """Test that application works with url_base set to 'boxarr'."""
-    # Mock settings with url_base
+    # Mock settings with url_base and unconfigured state
     monkeypatch.setattr("src.utils.config.settings.boxarr_url_base", "boxarr")
+    monkeypatch.setattr("src.utils.config.settings.radarr_api_key", "")
     monkeypatch.setattr("src.api.app.settings.boxarr_url_base", "boxarr")
+    monkeypatch.setattr("src.api.routes.web.settings.radarr_api_key", "")
     
     # Create app with url_base
     app = create_app()
@@ -39,7 +58,20 @@ def test_url_base_boxarr(monkeypatch):
     assert response.status_code == 200
     assert response.json()["status"] == "healthy"
     
-    # Test redirect from root to dashboard with base path
+    # Test redirect from root to setup with base path (unconfigured)
+    response = client.get("/boxarr/", follow_redirects=False)
+    assert response.status_code == 307
+    assert response.headers["location"] == "/boxarr/setup"
+    
+    # Test with configured state
+    monkeypatch.setattr("src.utils.config.settings.radarr_api_key", "test_key")
+    monkeypatch.setattr("src.api.routes.web.settings.radarr_api_key", "test_key")
+    
+    # Recreate app
+    app = create_app()
+    client = TestClient(app)
+    
+    # Now should redirect to dashboard
     response = client.get("/boxarr/", follow_redirects=False)
     assert response.status_code == 307
     assert response.headers["location"] == "/boxarr/dashboard"
@@ -52,9 +84,11 @@ def test_url_base_boxarr(monkeypatch):
 
 def test_url_base_nested_path(monkeypatch):
     """Test that application works with nested url_base like 'apps/boxarr'."""
-    # Mock settings with nested url_base
+    # Mock settings with nested url_base and configured state
     monkeypatch.setattr("src.utils.config.settings.boxarr_url_base", "apps/boxarr")
+    monkeypatch.setattr("src.utils.config.settings.radarr_api_key", "test_key")
     monkeypatch.setattr("src.api.app.settings.boxarr_url_base", "apps/boxarr")
+    monkeypatch.setattr("src.api.routes.web.settings.radarr_api_key", "test_key")
     
     # Create app with nested url_base
     app = create_app()
@@ -65,7 +99,7 @@ def test_url_base_nested_path(monkeypatch):
     assert response.status_code == 200
     assert response.json()["status"] == "healthy"
     
-    # Test redirect with nested base path
+    # Test redirect with nested base path (configured, goes to dashboard)
     response = client.get("/apps/boxarr/", follow_redirects=False)
     assert response.status_code == 307
     assert response.headers["location"] == "/apps/boxarr/dashboard"
@@ -89,17 +123,19 @@ def test_url_base_normalization(monkeypatch):
 
 def test_javascript_base_path_injection(monkeypatch):
     """Test that base path is correctly injected for JavaScript."""
-    # Mock settings with url_base
+    # Mock settings with url_base and unconfigured state to go to setup
     monkeypatch.setattr("src.utils.config.settings.boxarr_url_base", "boxarr")
+    monkeypatch.setattr("src.utils.config.settings.radarr_api_key", "")
     monkeypatch.setattr("src.api.app.settings.boxarr_url_base", "boxarr")
+    monkeypatch.setattr("src.api.routes.web.settings.radarr_api_key", "")
     
     app = create_app()
     client = TestClient(app)
     
-    # Request dashboard page to check JavaScript injection
-    response = client.get("/boxarr/dashboard")
+    # Request setup page (since we're unconfigured)
+    response = client.get("/boxarr/setup")
     
     # Check that base path is injected into JavaScript
-    if response.status_code == 200:  # Only if dashboard loads
-        assert "window.BOXARR_BASE_PATH" in response.text
-        # The exact value depends on template rendering
+    assert response.status_code == 200
+    assert "window.BOXARR_BASE_PATH" in response.text
+    assert '/boxarr' in response.text  # Should see the base path somewhere


### PR DESCRIPTION
## Summary
This PR implements comprehensive URL base support to enable Boxarr to run behind reverse proxies at custom paths like `/boxarr` or `/apps/media/boxarr` while maintaining full backward compatibility.

Resolves #22

## Key Changes

### Configuration & Backend
- Added `boxarr_url_base` configuration setting with validation (strips leading/trailing slashes)
- Implemented FastAPI `root_path` parameter for proper URL handling
- Added `ProxyHeadersMiddleware` for reverse proxy support (removed overly permissive `trusted_hosts`)
- Created Jinja2 global `url_for()` helper for cleaner template URL generation
- Fixed all redirects to use dynamic base paths
- Fixed widget endpoint to generate correct absolute URLs

### Frontend & JavaScript
- Created JavaScript URL helper functions (`makeUrl`, `apiUrl`, `safeUrl`)
- Added path detection helpers (`isCurrentPath`, `getPathWithoutBase`)
- Updated all 20+ API calls to use dynamic URL construction
- Fixed JavaScript path comparisons to handle base paths correctly
- Injected `BOXARR_BASE_PATH` in all templates including setup.html
- Fixed active nav highlighting in templates using `path.endswith()`

### Testing
- Added comprehensive integration tests for URL base scenarios
- Tests cover empty base, single path, and nested paths
- Fixed tests to handle both configured and unconfigured states
- All tests passing ✅

## Test Plan
- [x] Run with empty `url_base` (default) - backward compatibility verified
- [x] Run with `BOXARR_URL_BASE=boxarr` - single path works
- [x] Run with `BOXARR_URL_BASE=apps/boxarr` - nested paths work
- [x] Test health endpoint with all scenarios
- [x] Test redirects (unconfigured → setup, configured → dashboard)
- [x] Test widget URL generation
- [x] Test JavaScript functionality on setup page
- [x] Test active nav highlighting
- [x] Run integration test suite - all tests pass

## Configuration Examples

### Environment Variable
```bash
BOXARR_URL_BASE=boxarr python -m src.main
```

### YAML Configuration
```yaml
boxarr:
  url_base: boxarr  # or "apps/media/boxarr" for nested paths
```

### Nginx Reverse Proxy Example
```nginx
location /boxarr/ {
    proxy_pass http://localhost:8888/;
    proxy_set_header Host $host;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Proto $scheme;
    proxy_set_header X-Forwarded-Prefix /boxarr;
}
```

## Breaking Changes
None - full backward compatibility maintained. Empty `url_base` works exactly as before.

🤖 Generated with [Claude Code](https://claude.ai/code)