### PR TITLE
fix: Restore delete week functionality

### DIFF
--- a/src/web/templates/dashboard.html
+++ b/src/web/templates/dashboard.html
@@ -1539,13 +1539,30 @@ function fetchHistoricalWeek() {
     updateHistoricalWeek();
 }
 
-function deleteWeek(year, week) {
+async function deleteWeek(year, week) {
     if (!confirm(`Are you sure you want to delete Week ${week}, ${year}?`)) {
         return;
     }
     
-    // Implementation would go here
-    alert('Delete functionality not yet implemented');
+    try {
+        const response = await fetch(apiUrl(`/api/weeks/${year}/W${week}/delete`), {
+            method: 'DELETE',
+            headers: {'Content-Type': 'application/json'}
+        });
+        
+        const data = await response.json();
+        
+        if (data.success) {
+            alert(`Successfully deleted Week ${week}, ${year}`);
+            // Reload the page to reflect the changes
+            window.location.reload();
+        } else {
+            alert(`Failed to delete week: ${data.message || 'Unknown error'}`);
+        }
+    } catch (error) {
+        console.error('Error deleting week:', error);
+        alert(`Error deleting week: ${error.message}`);
+    }
 }
 
 function changePageSize(size) {


### PR DESCRIPTION
## Summary
- Fixed the delete week functionality that was showing "not implemented" message
- Connected the frontend to the existing backend DELETE endpoint
- The backend endpoint was already working, but the frontend wasn't calling it

## Changes
- Updated `deleteWeek()` function in dashboard.html to make actual API call
- Added async/await pattern for proper error handling
- Added success/failure feedback to user
- Page automatically reloads after successful deletion

## Testing
- [x] All unit tests pass
- [x] Black formatting check passes
- [x] Delete functionality now properly calls `/api/weeks/{year}/W{week}/delete`
- [x] Proper confirmation dialog before deletion
- [x] Success/error messages displayed to user

## Root Cause
The backend API endpoint was fully implemented and working, but the frontend JavaScript function was just showing a placeholder alert instead of making the API call.

🤖 Generated with [Claude Code](https://claude.ai/code)