### PR TITLE
UI: Minimum Availability (Radarr) — toggle + select; top-level payload; rename section

### DIFF
--- a/src/api/routes/config.py
+++ b/src/api/routes/config.py
@@ -41,6 +41,9 @@ class SaveConfigRequest(BaseModel):
     radarr_root_folder: str = "/movies"
     radarr_quality_profile_default: str = "HD-1080p"
     radarr_quality_profile_upgrade: str = ""  # Optional, empty string means no upgrade
+    # Minimum availability controls
+    radarr_minimum_availability_enabled: bool = False
+    radarr_minimum_availability: str = "announced"
     # Root folder mapping configuration
     radarr_root_folder_config: Optional[RootFolderConfig] = None
     boxarr_scheduler_enabled: bool = True
@@ -170,6 +173,15 @@ async def save_configuration(config: SaveConfigRequest):
             "root_folder": config.radarr_root_folder,
             "quality_profile_default": config.radarr_quality_profile_default,
         }
+
+        # Include minimum availability settings (UI-driven)
+        radarr_config["minimum_availability_enabled"] = (
+            bool(config.radarr_minimum_availability_enabled)
+        )
+        if config.radarr_minimum_availability:
+            radarr_config["minimum_availability"] = (
+                config.radarr_minimum_availability
+            )
 
         # Only include upgrade profile if specified
         if config.radarr_quality_profile_upgrade:

--- a/src/api/routes/web.py
+++ b/src/api/routes/web.py
@@ -439,6 +439,9 @@ async def setup_page(request: Request):
             root_folder=str(settings.radarr_root_folder),
             quality_profile_default=settings.radarr_quality_profile_default,
             quality_profile_upgrade=settings.radarr_quality_profile_upgrade,
+            # Minimum availability controls
+            radarr_minimum_availability_enabled=settings.radarr_minimum_availability_enabled,
+            radarr_minimum_availability=settings.radarr_minimum_availability.value,
             # Root folder mapping configuration
             root_folder_mapping_enabled=settings.radarr_root_folder_config.enabled,
             root_folder_mappings=[

--- a/src/core/radarr.py
+++ b/src/core/radarr.py
@@ -358,17 +358,28 @@ class RadarrService:
             search_for_movie = settings.radarr_search_for_movie
 
         # Prepare movie data
+        add_options: Dict[str, Any] = {
+            "searchForMovie": search_for_movie,
+            "monitor": settings.radarr_monitor_option.value,
+        }
+
         movie_data: Dict[str, Any] = {
             **movie_info,
             "qualityProfileId": quality_profile_id,
             "rootFolderPath": root_folder,
             "monitored": monitored,
-            "addOptions": {
-                "searchForMovie": search_for_movie,
-                "monitor": settings.radarr_monitor_option.value,
-                "minimumAvailability": settings.radarr_minimum_availability.value,
-            },
+            "addOptions": add_options,
         }
+
+        # Radarr expects minimumAvailability at the top level of the movie payload,
+        # not inside addOptions. Only include it when the UI toggle is enabled.
+        try:
+            if getattr(settings, "radarr_minimum_availability_enabled", False):
+                movie_data["minimumAvailability"] = (
+                    settings.radarr_minimum_availability.value
+                )
+        except Exception:
+            pass
 
         # Apply auto-tagging if enabled
         try:

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -85,6 +85,11 @@ class Settings(BaseSettings):
     radarr_monitor_option: MonitorEnum = Field(
         default=MonitorEnum.MOVIE_ONLY, description="What to monitor when adding movies"
     )
+    # Minimum availability control (UI-driven)
+    radarr_minimum_availability_enabled: bool = Field(
+        default=False,
+        description="Enable setting a minimum availability when adding movies",
+    )
     radarr_minimum_availability: MinimumAvailabilityEnum = Field(
         default=MinimumAvailabilityEnum.ANNOUNCED,
         description="Minimum availability for movies",
@@ -298,6 +303,14 @@ class Settings(BaseSettings):
                                     for mapping in value["mappings"]
                                 ]
                             setattr(self, "radarr_root_folder_config", config)
+                        elif key == "minimum_availability":
+                            # Coerce string to enum safely
+                            try:
+                                enum_val = MinimumAvailabilityEnum(value)  # type: ignore[arg-type]
+                                setattr(self, "radarr_minimum_availability", enum_val)
+                            except Exception:
+                                # Fall back to default if invalid
+                                pass
                         else:
                             attr_name = f"radarr_{key}"
                             if hasattr(self, attr_name):

--- a/src/web/static/js/app.js
+++ b/src/web/static/js/app.js
@@ -115,6 +115,18 @@ function toggleAutoTag() {
     }
 }
 
+// Minimum Availability toggle
+function toggleMinimumAvailability() {
+    const checkbox = document.getElementById('minAvailabilityEnabled');
+    const select = document.getElementById('minimumAvailability');
+    if (checkbox && select) {
+        const enabled = checkbox.checked;
+        select.disabled = !enabled;
+        // Subtle UI cue by changing opacity
+        select.style.opacity = enabled ? '1' : '0.6';
+    }
+}
+
 function updateGenreMode() {
     const mode = document.querySelector('input[name="boxarr_features_auto_add_genre_filter_mode"]:checked');
     const label = document.getElementById('genreListLabel');
@@ -1464,6 +1476,15 @@ function reloadScheduler() {
                     saveBtn.disabled = true;
                 }
             }
+
+            // Initialize minimum availability toggle state and handler
+            try {
+                toggleMinimumAvailability();
+                const minAvailCheckbox = document.getElementById('minAvailabilityEnabled');
+                if (minAvailCheckbox) {
+                    minAvailCheckbox.addEventListener('change', toggleMinimumAvailability);
+                }
+            } catch (_) { /* ignore */ }
         }
         
         // Add CSS animations if not present

--- a/src/web/templates/setup.html
+++ b/src/web/templates/setup.html
@@ -63,9 +63,9 @@
                 <div id="testResults" class="test-results"></div>
             </div>
 
-            <!-- Quality Settings Section -->
+            <!-- Radarr Settings Section -->
             <div id="qualitySection" class="form-section quality-section {% if is_configured %}show{% endif %}">
-                <h2 class="section-title">Quality Settings</h2>
+                <h2 class="section-title">Radarr Settings</h2>
                 
                 <div class="form-group">
                     <label for="rootFolder" class="form-label">Root Folder</label>
@@ -98,6 +98,26 @@
                             {% endif %}
                         </select>
                         <small class="text-muted">Higher quality option for manual upgrades</small>
+                    </div>
+                </div>
+
+                <!-- Minimum Availability Control Row -->
+                <div class="form-row two-col" style="margin-top: 0.75rem; align-items: center;">
+                    <div class="form-group" style="margin-bottom: 0;">
+                        <div class="checkbox-group" style="margin-bottom: 0;">
+                            <input type="checkbox" id="minAvailabilityEnabled" name="radarr_minimum_availability_enabled" class="checkbox-input" {% if radarr_minimum_availability_enabled %}checked{% endif %} onchange="toggleMinimumAvailability()">
+                            <div>
+                                <label for="minAvailabilityEnabled" class="checkbox-label main">Set minimum availability</label>
+                                <div class="checkbox-label description">When enabled, movies added to Radarr will use the selected minimum availability</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="form-group" style="margin-bottom: 0;">
+                        <select id="minimumAvailability" name="radarr_minimum_availability" class="form-select" {% if not radarr_minimum_availability_enabled %}disabled{% endif %}>
+                            <option value="announced" {% if radarr_minimum_availability == 'announced' %}selected{% endif %}>Announced</option>
+                            <option value="inCinemas" {% if radarr_minimum_availability == 'inCinemas' %}selected{% endif %}>In Cinemas</option>
+                            <option value="released" {% if radarr_minimum_availability == 'released' %}selected{% endif %}>Released</option>
+                        </select>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Implements feature request #34: UI-driven Minimum Availability for Radarr.

Summary
- Adds Settings → Radarr Settings row with a checkbox “Set minimum availability” and a select (“Announced”, “In Cinemas”, “Released”). Default unchecked.
- Persists to config under `radarr.minimum_availability_enabled` (bool) and `radarr.minimum_availability` (string).
- When enabled, `minimumAvailability` is included at the top-level of the Radarr add payload (Radarr expects top-level, not inside `addOptions`). When disabled, it is omitted (back-compat behavior).
- Renames “Quality Settings” section to “Radarr Settings”.
- Removes “Pre-DB” from the UI to match Radarr variants that don’t expose it.

Files
- src/utils/config.py — add enabled flag; YAML load for `minimum_availability` string → enum.
- src/api/routes/config.py — accept + save the new fields into `local.yaml`.
- src/api/routes/web.py — feed template with enabled flag + current value.
- src/web/templates/setup.html — render checkbox + select on one row; rename section.
- src/web/static/js/app.js — toggle handler to enable/disable select.
- src/core/radarr.py — include top-level `minimumAvailability` only when enabled.

Validation
- Local tests: `pytest` passing.
- Manual: enable the toggle, pick an option, save, add a movie; Radarr shows the chosen Minimum Availability on the movie.

Notes
- No change to default behavior when the toggle is off.
- Keeps existing env vars compatible.
