### PR TITLE
fix/issue 58 add cache and exists

### DIFF
--- a/src/web/templates/overview.html
+++ b/src/web/templates/overview.html
@@ -607,7 +607,7 @@
                 <!-- Actions -->
                 <div class="movie-actions">
                     {% if not movie.radarr_id %}
-                    <button class="action-btn add-to-radarr" onclick="addToRadarr('{{ movie.title }}', {{ movie.year or 'null' }}, this)">
+                    <button class="action-btn add-to-radarr" onclick='addToRadarr({{ movie.title|tojson }}, {{ movie.year or "null" }}, this)'>
                         Add to Radarr
                     </button>
                     {% elif movie.can_upgrade_quality %}

--- a/src/web/templates/weekly.html
+++ b/src/web/templates/weekly.html
@@ -440,7 +440,7 @@
                 <!-- Actions -->
                 <div class="movie-actions">
                     {% if not movie.radarr_id %}
-                    <button class="action-btn add-to-radarr" onclick="addToRadarr('{{ movie.title }}', {{ movie.year or 'null' }}, this)">
+                    <button class="action-btn add-to-radarr" onclick='addToRadarr({{ movie.title|tojson }}, {{ movie.year or "null" }}, this)'>
                         Add to Radarr
                     </button>
                     {% elif movie.can_upgrade_quality %}


### PR DESCRIPTION
- **fix: Multiple critical improvements and bug fixes**
- **style: Apply Black formatting to fix CI**
- **fix: Add type annotations to fix MyPy errors**
- **fix: Apply Black formatting to type annotations**
- **fix: Sort imports alphabetically (isort)**
- **fix: Sort typing imports alphabetically (isort)**
- **Release version 1.3.7**
- **feat: Add Radarr root folder mapping support (#38)**
- **Feature/wiki documentation (#40)**
- **Add 'Ignore re-releases' auto-add filter (#37) (#41)**
- **Release version 1.4.0**
- **Feature/add logo to UI (#42)**
- **Update README.md**
- **Update README.md**
- **Update README.md**
- **chore: Cleaned up README.md**
- **Release version 1.4.1**
- **feat(radarr): auto-tag added movies; default tag 'boxarr'**
- **Speed up initial load with per-page Radarr hydration**
- **UI: add "Set minimum availability" toggle + select; persist in config; send minimumAvailability at top-level when enabled; rename section to 'Radarr Settings'; remove Pre-DB option. Closes #34**
- **Format: satisfy Black in config save (inline bool wrapping)**
- **Format: inline minimum_availability assignment to satisfy Black**
- **Fix: remove unused mypy ignore in YAML loader**
- **Release version 1.5.0**
- **Bug: #58**
- **Bug: #58**
- **Release version 1.5.1**
- **chore: format test to satisfy Black (CI)**
- **test: set httpx Request on fake responses to satisfy raise_for_status**
- **Release version 1.5.2**
- **Fix: prevent duplicate add, bust Radarr cache after add, force fresh library on regenerate; escape titles in inline JS for apostrophes; improve Radarr error logging. Closes #58**
