### PR TITLE
fix: remove unused type: ignore that breaks CI

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -50,7 +50,7 @@ def create_app(scheduler: Optional[BoxarrScheduler] = None) -> FastAPI:
     # Add ProxyHeadersMiddleware to handle reverse proxy headers
     # Note: Remove trusted_hosts parameter for better security
     # Only add specific hosts if needed: trusted_hosts=["proxy.example.com"]
-    app.add_middleware(ProxyHeadersMiddleware)  # type: ignore[arg-type]
+    app.add_middleware(ProxyHeadersMiddleware)
 
     # Add CORS middleware for local network access
     app.add_middleware(


### PR DESCRIPTION
## Summary
- Remove the `# type: ignore[arg-type]` comment on `app.add_middleware(ProxyHeadersMiddleware)` in `src/api/app.py`
- CI mypy flags this as an unused ignore comment, causing the pipeline to fail

## Test plan
- [ ] CI mypy step passes (no more "Unused type: ignore" error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)