### PR TITLE
fix: increase Radarr API timeout to 120s (configurable)

### DIFF
--- a/src/core/radarr.py
+++ b/src/core/radarr.py
@@ -118,7 +118,7 @@ class RadarrService:
         self.client = http_client or httpx.Client(
             base_url=self.url,
             headers={"X-Api-Key": self.api_key},
-            timeout=30.0,
+            timeout=getattr(settings, "radarr_timeout", 120.0),
             follow_redirects=True,
         )
 

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -97,6 +97,12 @@ class Settings(BaseSettings):
     radarr_search_for_movie: bool = Field(
         default=True, description="Search for movie after adding"
     )
+    radarr_timeout: float = Field(
+        default=120.0,
+        ge=5,
+        le=600,
+        description="HTTP timeout in seconds for Radarr API requests",
+    )
     radarr_root_folder_config: RootFolderConfig = Field(
         default_factory=RootFolderConfig,
         description="Configuration for root folder mappings",


### PR DESCRIPTION
## Summary
- Add `radarr_timeout` setting (default 120s, configurable via `RADARR_TIMEOUT` env var)
- Replace hardcoded 30s timeout in `RadarrService` with configurable value
- Fixes timeout failures for users with large Radarr libraries

Closes #62

## Test plan
- [ ] CI passes
- [ ] Verify `RADARR_TIMEOUT=300` results in 300s timeout on the httpx client

🤖 Generated with [Claude Code](https://claude.com/claude-code)