### PR TITLE
fix: respect TZ env var for scheduler timezone

### DIFF
--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -130,7 +130,8 @@ class Settings(BaseSettings):
         description="Cron expression for updates (default: Tuesday 11 PM)",
     )
     boxarr_scheduler_timezone: str = Field(
-        default="America/New_York", description="Timezone for scheduler"
+        default_factory=lambda: os.environ.get("TZ", "America/New_York"),
+        description="Timezone for scheduler",
     )
 
     # UI Configuration


### PR DESCRIPTION
## Summary
- `boxarr_scheduler_timezone` now defaults to the `TZ` environment variable when set
- Falls back to `America/New_York` if neither `BOXARR_SCHEDULER_TIMEZONE` nor `TZ` is set
- Users can now set `TZ=Europe/London` in Docker and have the scheduler respect it

Closes #74

## Test plan
- [ ] CI passes
- [ ] Set `TZ=Europe/London` without `BOXARR_SCHEDULER_TIMEZONE` → scheduler uses Europe/London
- [ ] Set `BOXARR_SCHEDULER_TIMEZONE=Asia/Tokyo` with `TZ=Europe/London` → scheduler uses Asia/Tokyo (explicit wins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)