### PR TITLE
fix: add scroll to modal when content overflows viewport

### DIFF
--- a/src/web/templates/dashboard.html
+++ b/src/web/templates/dashboard.html
@@ -322,6 +322,8 @@
     border-radius: 12px;
     width: 90%;
     max-width: 500px;
+    max-height: 80vh;
+    overflow-y: auto;
     box-shadow: var(--shadow-lg);
 }
 


### PR DESCRIPTION
## Summary
- Add `max-height: 80vh` and `overflow-y: auto` to `.modal-content`
- Prevents the "Update Historical Data" modal from overflowing the viewport
- Ensures the "Update Range" button is always reachable

Closes #70

## Test plan
- [ ] CI passes
- [ ] Open dashboard → "Update Historical Data" → select "Week Range" → pick a preset with many weeks → confirm modal scrolls and button is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)