### PR TITLE
fix: support PORT env var as fallback for web port

### DIFF
--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -239,6 +239,15 @@ class Settings(BaseSettings):
         description="Log format string",
     )
 
+    @validator("boxarr_port", pre=True)
+    def check_port_env(cls, v: int) -> int:
+        """Fall back to PORT env var when boxarr_port is at its default."""
+        if v == 8888:
+            port_env = os.environ.get("PORT")
+            if port_env:
+                return int(port_env)
+        return v
+
     @validator("boxarr_url_base")
     def normalize_url_base(cls, v: str) -> str:
         """Normalize URL base by stripping leading/trailing slashes."""


### PR DESCRIPTION
## Summary
- Add validator on `boxarr_port` that checks the `PORT` environment variable as a fallback
- Only applies when `BOXARR_PORT` is not explicitly set (value is at default 8888)
- `BOXARR_PORT` still takes precedence when explicitly set

Closes #71

## Test plan
- [ ] CI passes
- [ ] `PORT=9999` (without `BOXARR_PORT`) → app listens on port 9999
- [ ] `BOXARR_PORT=7777 PORT=9999` → app listens on port 7777 (explicit wins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)