### PR TITLE
feat: configurable box office fetch limit (1-30)

### DIFF
--- a/src/api/routes/config.py
+++ b/src/api/routes/config.py
@@ -50,6 +50,8 @@ class SaveConfigRequest(BaseModel):
     boxarr_scheduler_cron: str = "0 23 * * 2"
     boxarr_features_auto_add: bool = True
     boxarr_features_quality_upgrade: bool = True
+    # Box office fetch limit
+    boxarr_features_box_office_limit: int = 10
     # New auto-add advanced options
     boxarr_features_auto_add_limit: int = 10
     boxarr_features_auto_add_genre_filter_enabled: bool = False
@@ -258,6 +260,7 @@ async def save_configuration(config: SaveConfigRequest):
                 "features": {
                     "auto_add": config.boxarr_features_auto_add,
                     "quality_upgrade": config.boxarr_features_quality_upgrade,
+                    "box_office_limit": config.boxarr_features_box_office_limit,
                     "auto_tag_enabled": config.boxarr_features_auto_tag_enabled,
                     "auto_tag_text": config.boxarr_features_auto_tag_text,
                     "auto_add_options": {

--- a/src/api/routes/scheduler.py
+++ b/src/api/routes/scheduler.py
@@ -277,7 +277,10 @@ async def update_specific_week(request: UpdateWeekRequest):  # noqa: C901
 
         # Get box office data
         boxoffice_service = BoxOfficeService()
-        box_office_movies = boxoffice_service.fetch_weekend_box_office(year, week)
+        limit = settings.boxarr_features_box_office_limit
+        box_office_movies = boxoffice_service.fetch_weekend_box_office(
+            year, week, limit=limit
+        )
 
         if not box_office_movies:
             return {

--- a/src/api/routes/web.py
+++ b/src/api/routes/web.py
@@ -460,6 +460,8 @@ async def setup_page(request: Request):
             scheduler_time=current_time,
             auto_add=settings.boxarr_features_auto_add,
             quality_upgrade=settings.boxarr_features_quality_upgrade,
+            # Box office fetch limit
+            box_office_limit=settings.boxarr_features_box_office_limit,
             # Auto tagging
             auto_tag_enabled=settings.boxarr_features_auto_tag_enabled,
             auto_tag_text=settings.boxarr_features_auto_tag_text,

--- a/src/core/boxoffice.py
+++ b/src/core/boxoffice.py
@@ -139,7 +139,10 @@ class BoxOfficeService:
             return None
 
     def fetch_weekend_box_office(
-        self, year: Optional[int] = None, week: Optional[int] = None
+        self,
+        year: Optional[int] = None,
+        week: Optional[int] = None,
+        limit: int = 10,
     ) -> List[BoxOfficeMovie]:
         """
         Fetch box office data for a specific weekend.
@@ -171,11 +174,13 @@ class BoxOfficeService:
             logger.error(f"Failed to fetch box office data: {e}")
             raise BoxOfficeError(f"Failed to fetch box office data: {e}") from e
 
-        movies = self.parse_box_office_html(response.text)
+        movies = self.parse_box_office_html(response.text, limit=limit)
         self.enrich_with_imdb_ids(movies)
         return movies
 
-    def parse_box_office_html(self, html: str) -> List[BoxOfficeMovie]:  # noqa: C901
+    def parse_box_office_html(
+        self, html: str, limit: int = 10
+    ) -> List[BoxOfficeMovie]:  # noqa: C901
         """
         Parse box office data from HTML.
 
@@ -196,14 +201,14 @@ class BoxOfficeService:
             table = soup.find("table", class_="a-bordered")
             if not table:
                 # Try alternative parsing method for different page structure
-                return self._parse_alternative_format(html)
+                return self._parse_alternative_format(html, limit=limit)
 
             # Parse table rows
             rows = (
                 table.find_all("tr")[1:] if hasattr(table, "find_all") else []
             )  # Skip header row
 
-            for idx, row in enumerate(rows[:10], start=1):  # Top 10 only
+            for idx, row in enumerate(rows[:limit], start=1):
                 cells = row.find_all("td")
                 if len(cells) < 3:
                     continue
@@ -272,7 +277,9 @@ class BoxOfficeService:
             logger.error(f"Failed to parse box office HTML: {e}")
             raise BoxOfficeError(f"Failed to parse box office data: {e}") from e
 
-    def _parse_alternative_format(self, html: str) -> List[BoxOfficeMovie]:
+    def _parse_alternative_format(
+        self, html: str, limit: int = 10
+    ) -> List[BoxOfficeMovie]:
         """
         Parse box office data using regex pattern (fallback method).
 
@@ -298,7 +305,7 @@ class BoxOfficeService:
             movies.append(movie)
             rank += 1
 
-            if rank > 10:
+            if rank > limit:
                 break
 
         if not movies:
@@ -370,11 +377,14 @@ class BoxOfficeService:
         ]
         return any(keyword.lower() in text.lower() for keyword in studio_keywords)
 
-    def get_current_week_movies(self) -> List[BoxOfficeMovie]:
+    def get_current_week_movies(self, limit: int = 10) -> List[BoxOfficeMovie]:
         """
         Get current week's box office movies.
         Actually fetches the previous week's data since box office data
         is only available after the weekend ends.
+
+        Args:
+            limit: Maximum number of movies to fetch
 
         Returns:
             List of BoxOfficeMovie objects
@@ -384,7 +394,7 @@ class BoxOfficeService:
 
         last_week = datetime.now() - timedelta(weeks=1)
         _, _, year, week = self.get_weekend_dates(last_week)
-        return self.fetch_weekend_box_office(year, week)
+        return self.fetch_weekend_box_office(year, week, limit=limit)
 
     def get_historical_movies(
         self, weeks_back: int = 1

--- a/src/core/scheduler.py
+++ b/src/core/scheduler.py
@@ -167,13 +167,17 @@ class BoxarrScheduler:
                 )
 
             # Fetch box office movies for specified or current week
+            limit = settings.boxarr_features_box_office_limit
             if year and week:
                 box_office_movies = await self._run_in_executor(
-                    self.boxoffice_service.fetch_weekend_box_office, year, week
+                    self.boxoffice_service.fetch_weekend_box_office,
+                    year,
+                    week,
+                    limit,
                 )
             else:
                 box_office_movies = await self._run_in_executor(
-                    self.boxoffice_service.get_current_week_movies
+                    self.boxoffice_service.get_current_week_movies, limit
                 )
 
             # Fetch Radarr movies

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -163,6 +163,12 @@ class Settings(BaseSettings):
     )
 
     # Feature Flags
+    boxarr_features_box_office_limit: int = Field(
+        default=10,
+        ge=1,
+        le=30,
+        description="Number of movies to fetch from Box Office Mojo (1-30)",
+    )
     boxarr_features_auto_add: bool = Field(
         default=False, description="Automatically add movies to Radarr"
     )
@@ -185,8 +191,8 @@ class Settings(BaseSettings):
     boxarr_features_auto_add_limit: int = Field(
         default=10,
         ge=1,
-        le=10,
-        description="Maximum number of movies to auto-add (1-10)",
+        le=30,
+        description="Maximum number of movies to auto-add (1-30)",
     )
     boxarr_features_auto_add_genre_filter_enabled: bool = Field(
         default=False, description="Enable genre filtering for auto-add"

--- a/src/web/static/js/app.js
+++ b/src/web/static/js/app.js
@@ -1251,6 +1251,8 @@ function reloadScheduler() {
         const autoTagInput = document.getElementById('autoTagText');
         config.boxarr_features_auto_tag_text = (autoTagInput && autoTagInput.value) ? autoTagInput.value : 'boxarr';
         
+        // Box office fetch limit
+        config.boxarr_features_box_office_limit = parseInt(document.getElementById('boxOfficeLimit')?.value || '10');
         // Handle new auto-add advanced options
         config.boxarr_features_auto_add_limit = parseInt(document.getElementById('autoAddLimit')?.value || '10');
         config.boxarr_features_auto_add_genre_filter_enabled = document.getElementById('genreFilterEnabled')?.checked || false;

--- a/src/web/templates/setup.html
+++ b/src/web/templates/setup.html
@@ -194,13 +194,24 @@
                     <small class="text-muted">Single word, up to 20 characters.</small>
                 </div>
                 
+                <!-- Box Office Fetch Limit -->
+                <div class="form-group" style="margin-top: 1rem;">
+                    <label for="boxOfficeLimit" class="form-label">Box Office Fetch Limit</label>
+                    <select id="boxOfficeLimit" name="boxarr_features_box_office_limit" class="form-select">
+                        {% for i in [5, 10, 15, 20, 25, 30] %}
+                        <option value="{{ i }}" {% if box_office_limit == i %}selected{% endif %}>{{ i }} movies</option>
+                        {% endfor %}
+                    </select>
+                    <small class="text-muted">Number of movies to fetch from Box Office Mojo each week (1-30)</small>
+                </div>
+
                 <!-- Auto-Add Advanced Options -->
                 <div id="autoAddOptions" class="auto-add-options {% if auto_add %}active{% endif %}" style="margin-left: 2rem; margin-top: 1rem; padding: 1rem; background: var(--bg-color); border-radius: 8px; border-left: 3px solid var(--primary-color);">
                     <!-- Top X Movies Limit -->
                     <div class="form-group">
                         <label for="autoAddLimit" class="form-label">Maximum Movies to Add</label>
                         <select id="autoAddLimit" name="boxarr_features_auto_add_limit" class="form-select">
-                            {% for i in range(1, 11) %}
+                            {% for i in range(1, 31) %}
                             <option value="{{ i }}" {% if auto_add_limit == i %}selected{% endif %}>{{ i }} movie{% if i > 1 %}s{% endif %}</option>
                             {% endfor %}
                         </select>

--- a/tests/unit/test_box_office_limit.py
+++ b/tests/unit/test_box_office_limit.py
@@ -1,0 +1,144 @@
+"""Unit tests for box office fetch limit configuration."""
+
+from unittest.mock import patch
+
+import pytest
+
+from src.core.boxoffice import BoxOfficeService
+
+
+def _make_html(num_movies: int) -> str:
+    """Generate Box Office Mojo-style HTML with the given number of movies."""
+    rows = []
+    for i in range(1, num_movies + 1):
+        rows.append(
+            f"""<tr>
+                <td>{i}</td>
+                <td>-</td>
+                <td><a href="/release/rl{i}/">Movie {i}</a></td>
+                <td>${i * 10_000_000:,}</td>
+                <td>-</td>
+                <td>-</td>
+                <td>{3000 + i}</td>
+                <td>${i * 50_000_000:,}</td>
+                <td>-</td>
+                <td>1</td>
+            </tr>"""
+        )
+    return f"""<html><body>
+        <table class="a-bordered">
+            <tr><th>Rank</th><th>LW</th><th>Movie</th><th>Weekend</th></tr>
+            {"".join(rows)}
+        </table>
+    </body></html>"""
+
+
+def _make_alt_html(num_movies: int) -> str:
+    """Generate alternative-format HTML with the given number of movies."""
+    links = []
+    for i in range(1, num_movies + 1):
+        links.append(f'<a href="/release/rl{i:010d}/?ref_=bo_we_table_1">Movie {i}</a>')
+    return f"<html><body>{''.join(links)}</body></html>"
+
+
+class TestParseBoxOfficeLimit:
+    """Test that the limit parameter controls how many movies are returned."""
+
+    def setup_method(self):
+        self.service = BoxOfficeService()
+
+    def test_default_limit_returns_10(self):
+        """Default limit=10 preserves backward compatibility."""
+        html = _make_html(20)
+        movies = self.service.parse_box_office_html(html)
+        assert len(movies) == 10
+
+    def test_limit_5_returns_at_most_5(self):
+        """Limit=5 returns at most 5 movies."""
+        html = _make_html(20)
+        movies = self.service.parse_box_office_html(html, limit=5)
+        assert len(movies) == 5
+        assert movies[0].title == "Movie 1"
+        assert movies[4].title == "Movie 5"
+
+    def test_limit_20_returns_up_to_20(self):
+        """Limit=20 returns up to 20 movies if HTML has that many."""
+        html = _make_html(25)
+        movies = self.service.parse_box_office_html(html, limit=20)
+        assert len(movies) == 20
+
+    def test_limit_larger_than_available(self):
+        """Limit larger than available rows returns all available."""
+        html = _make_html(7)
+        movies = self.service.parse_box_office_html(html, limit=30)
+        assert len(movies) == 7
+
+    def test_limit_1(self):
+        """Limit=1 returns exactly one movie."""
+        html = _make_html(10)
+        movies = self.service.parse_box_office_html(html, limit=1)
+        assert len(movies) == 1
+        assert movies[0].rank == 1
+
+
+class TestAlternativeFormatLimit:
+    """Test that _parse_alternative_format respects the limit parameter."""
+
+    def setup_method(self):
+        self.service = BoxOfficeService()
+
+    def test_alt_default_limit(self):
+        """Alternative format defaults to 10."""
+        html = _make_alt_html(20)
+        movies = self.service._parse_alternative_format(html)
+        assert len(movies) == 10
+
+    def test_alt_limit_5(self):
+        """Alternative format respects limit=5."""
+        html = _make_alt_html(20)
+        movies = self.service._parse_alternative_format(html, limit=5)
+        assert len(movies) == 5
+
+    def test_alt_limit_20(self):
+        """Alternative format respects limit=20."""
+        html = _make_alt_html(25)
+        movies = self.service._parse_alternative_format(html, limit=20)
+        assert len(movies) == 20
+
+
+class TestConfigDefaults:
+    """Test configuration defaults for box_office_limit."""
+
+    def test_default_box_office_limit(self):
+        """Default box_office_limit is 10."""
+        from src.utils.config import Settings
+
+        s = Settings()
+        assert s.boxarr_features_box_office_limit == 10
+
+    def test_box_office_limit_range(self):
+        """box_office_limit must be between 1 and 30."""
+        from pydantic import ValidationError
+
+        from src.utils.config import Settings
+
+        with pytest.raises(ValidationError):
+            Settings(boxarr_features_box_office_limit=0)
+        with pytest.raises(ValidationError):
+            Settings(boxarr_features_box_office_limit=31)
+
+    def test_auto_add_limit_max_raised_to_30(self):
+        """auto_add_limit max is now 30."""
+        from src.utils.config import Settings
+
+        s = Settings(boxarr_features_auto_add_limit=30)
+        assert s.boxarr_features_auto_add_limit == 30
+
+    def test_auto_add_limit_rejects_above_30(self):
+        """auto_add_limit above 30 is rejected."""
+        from pydantic import ValidationError
+
+        from src.utils.config import Settings
+
+        with pytest.raises(ValidationError):
+            Settings(boxarr_features_auto_add_limit=31)


### PR DESCRIPTION
## Summary
- Adds `box_office_limit` config option (1-30, default 10) to control how many movies are scraped from Box Office Mojo per week
- Raises `auto_add_limit` ceiling from 10 to 30 so users can auto-add up to however many they fetch
- Adds "Box Office Fetch Limit" dropdown (5/10/15/20/25/30) to the setup page
- Passes limit through scraper → scheduler → routes pipeline

Closes #68

## Changed Files
| File | Change |
|------|--------|
| `src/utils/config.py` | New `boxarr_features_box_office_limit` field; `auto_add_limit` max → 30 |
| `src/core/boxoffice.py` | `limit` param on `fetch_weekend_box_office()`, `parse_box_office_html()`, `_parse_alternative_format()`, `get_current_week_movies()` |
| `src/core/scheduler.py` | Reads setting and passes limit to fetch calls |
| `src/api/routes/scheduler.py` | Passes limit in `update-week` route |
| `src/api/routes/config.py` | `SaveConfigRequest` field + YAML save |
| `src/api/routes/web.py` | Passes setting to setup template |
| `src/web/templates/setup.html` | Fetch limit dropdown; auto-add limit expanded to 30 |
| `src/web/static/js/app.js` | Sends `box_office_limit` in `saveConfiguration()` |
| `tests/unit/test_box_office_limit.py` | 12 new tests |

## Test plan
- [x] All 105 unit tests pass (`pytest tests/unit/ -v`)
- [x] Black/isort formatting clean
- [x] No new flake8 or mypy issues
- [ ] Manual: verify setup page shows new dropdown
- [ ] Manual: change limit to 20, trigger update, confirm 20 movies fetched


🤖 Generated with [Claude Code](https://claude.com/claude-code)