### PR TITLE
fix: incorrect weekend calculation on Fri-Sun (#96)

### DIFF
--- a/src/core/boxoffice.py
+++ b/src/core/boxoffice.py
@@ -77,13 +77,18 @@ class BoxOfficeService:
         if date is None:
             date = datetime.now()
 
-        # Find the most recent Friday
-        days_since_friday = (date.weekday() - 4) % 7
-        if days_since_friday == 0 and date.hour < 12:
-            # If it's Friday morning, use previous weekend
-            days_since_friday = 7
+        today = date.date()
+        weekday = today.weekday()  # Monday=0 ... Sunday=6
+        days_since_friday = (weekday - 4) % 7
 
-        friday = date - timedelta(days=days_since_friday)
+        # If today is Friday, Saturday, or Sunday, the weekend is NOT complete yet
+        # (Box Office Mojo publishes data on Monday), so go back to previous weekend
+        if weekday in (4, 5, 6):
+            days_since_friday += 7
+
+        friday = datetime.combine(
+            today - timedelta(days=days_since_friday), datetime.min.time()
+        )
         sunday = friday + timedelta(days=2)
 
         # Get ISO week number

--- a/src/core/scheduler.py
+++ b/src/core/scheduler.py
@@ -161,7 +161,6 @@ class BoxarrScheduler:
                 actual_week = week
             else:
                 # get_weekend_dates() returns the most recent complete weekend
-                # (Friday morning guard already handles runs on Friday before noon)
                 _, _, actual_year, actual_week = (
                     self.boxoffice_service.get_weekend_dates()
                 )

--- a/tests/unit/test_boxoffice.py
+++ b/tests/unit/test_boxoffice.py
@@ -1,12 +1,89 @@
 """Unit tests for box office parsing - focused on critical functionality."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock, Mock, patch
 
 import httpx
 import pytest
 
 from src.core.boxoffice import BoxOfficeError, BoxOfficeService
+
+
+class TestGetWeekendDates:
+    """Test weekend date calculation always returns the last completed weekend."""
+
+    def setup_method(self):
+        self.service = BoxOfficeService()
+
+    def test_monday_returns_previous_friday(self):
+        """Monday should return the just-completed weekend."""
+        # Monday 2026-03-09 -> previous Friday 2026-03-06
+        date = datetime(2026, 3, 9, 14, 0)
+        friday, sunday, year, week = self.service.get_weekend_dates(date)
+        assert friday.date().isoformat() == "2026-03-06"
+        assert sunday.date().isoformat() == "2026-03-08"
+
+    def test_tuesday_returns_previous_friday(self):
+        date = datetime(2026, 3, 10, 10, 0)
+        friday, sunday, _, _ = self.service.get_weekend_dates(date)
+        assert friday.date().isoformat() == "2026-03-06"
+
+    def test_wednesday_returns_previous_friday(self):
+        date = datetime(2026, 3, 11, 10, 0)
+        friday, sunday, _, _ = self.service.get_weekend_dates(date)
+        assert friday.date().isoformat() == "2026-03-06"
+
+    def test_thursday_returns_previous_friday(self):
+        date = datetime(2026, 3, 12, 10, 0)
+        friday, sunday, _, _ = self.service.get_weekend_dates(date)
+        assert friday.date().isoformat() == "2026-03-06"
+
+    def test_friday_returns_previous_friday(self):
+        """Friday should return the PREVIOUS completed weekend, not current."""
+        # Friday 2026-03-06 -> previous Friday 2026-02-27
+        date = datetime(2026, 3, 6, 18, 0)
+        friday, sunday, _, _ = self.service.get_weekend_dates(date)
+        assert friday.date().isoformat() == "2026-02-27"
+        assert sunday.date().isoformat() == "2026-03-01"
+
+    def test_friday_morning_returns_previous_friday(self):
+        """Friday morning should also return previous completed weekend."""
+        date = datetime(2026, 3, 6, 8, 0)
+        friday, _, _, _ = self.service.get_weekend_dates(date)
+        assert friday.date().isoformat() == "2026-02-27"
+
+    def test_saturday_returns_previous_friday(self):
+        """Saturday should return the PREVIOUS completed weekend."""
+        # Saturday 2026-03-07 -> previous Friday 2026-02-27
+        date = datetime(2026, 3, 7, 14, 0)
+        friday, sunday, _, _ = self.service.get_weekend_dates(date)
+        assert friday.date().isoformat() == "2026-02-27"
+        assert sunday.date().isoformat() == "2026-03-01"
+
+    def test_sunday_returns_previous_friday(self):
+        """Sunday should return the PREVIOUS completed weekend."""
+        # Sunday 2026-03-08 -> previous Friday 2026-02-27
+        date = datetime(2026, 3, 8, 20, 0)
+        friday, sunday, _, _ = self.service.get_weekend_dates(date)
+        assert friday.date().isoformat() == "2026-02-27"
+        assert sunday.date().isoformat() == "2026-03-01"
+
+    def test_returns_iso_year_and_week(self):
+        """Verify ISO year and week number are correct."""
+        # Monday 2026-03-09 -> Friday 2026-03-06 (ISO week 10)
+        date = datetime(2026, 3, 9)
+        _, _, year, week = self.service.get_weekend_dates(date)
+        assert year == 2026
+        assert week == 10
+
+    def test_friday_time_at_midnight(self):
+        """Return values should have time set to midnight."""
+        date = datetime(2026, 3, 9, 15, 30)
+        friday, sunday, _, _ = self.service.get_weekend_dates(date)
+        assert friday.hour == 0
+        assert friday.minute == 0
+        assert sunday.hour == 0
+        assert sunday.minute == 0
 
 
 class TestBoxOfficeHTMLParsing:


### PR DESCRIPTION
## Summary
- **Fixes** #96 — `get_weekend_dates()` returned the current (incomplete) weekend when run on Friday afternoon through Sunday, causing Box Office Mojo to return empty data
- Replaced the fragile `date.hour < 12` Friday-morning guard with a clean check: if today is Friday, Saturday, or Sunday (weekday 4–6), always go back to the previous completed weekend
- Removed stale comment in scheduler referencing the old "Friday morning guard"
- Added 11 unit tests covering every day of the week, time-of-day edge cases, ISO week correctness, and midnight normalization

## Test plan
- [x] All 127 tests pass (126 passed, 1 skipped)
- [x] New tests verify Monday–Thursday return the immediately preceding Friday
- [x] New tests verify Friday, Saturday, Sunday return the **previous** completed weekend (not current)
- [x] Friday morning and Friday afternoon both return the same (previous) weekend
- [x] ISO year/week numbers verified correct
- [x] Return values have time normalized to midnight

🤖 Generated with [Claude Code](https://claude.com/claude-code)