### PR TITLE
feat: add Ignored status to overview stats and filter; fix badge overlap and filter bleed

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,7 @@ on:
       - 'v*'
   release:
     types: [published]
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -48,10 +49,11 @@ jobs:
         images: |
           ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
+          type=ref,event=branch
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
-          type=raw,value=latest
+          type=raw,value=latest,enable={{is_default_branch}}
         labels: |
           org.opencontainers.image.title=Boxarr
           org.opencontainers.image.description=Box Office Tracking for Radarr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,12 @@ name: CI Pipeline
 
 on:
   pull_request:
+    branches: [ main, develop ]
     paths-ignore:
       - '**.md'
       - 'docs/**'
   push:
-    branches: [ main, develop, 'feature/**', 'fix/**' ]
+    branches: [ main, develop ]
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,11 @@ name: CI Pipeline
 
 on:
   pull_request:
-    branches: [ main, develop ]
     paths-ignore:
       - '**.md'
       - 'docs/**'
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, 'feature/**', 'fix/**' ]
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/src/api/routes/web.py
+++ b/src/api/routes/web.py
@@ -268,6 +268,7 @@ async def movie_overview_page(request: Request):
     recent_weeks = recent_weeks[:5]  # Show last 5 weeks
 
     return templates.TemplateResponse(
+        request,
         "overview.html",
         get_template_context(
             request,
@@ -422,6 +423,7 @@ async def dashboard_page(request: Request):
         filter_descriptions.append("Ignore re-releases")
 
     return templates.TemplateResponse(
+        request,
         "dashboard.html",
         get_template_context(
             request,
@@ -482,6 +484,7 @@ async def setup_page(request: Request):
     )  # Default to Tuesday if unknown
 
     return templates.TemplateResponse(
+        request,
         "setup.html",
         get_template_context(
             request,
@@ -624,6 +627,7 @@ async def serve_weekly_page(request: Request, year: int, week: int):
     ignored_tmdb_ids = list(ignore_list.get_ignored_tmdb_ids())
 
     return templates.TemplateResponse(
+        request,
         "weekly.html",
         get_template_context(
             request,

--- a/src/api/routes/web.py
+++ b/src/api/routes/web.py
@@ -191,21 +191,23 @@ async def movie_overview_page(request: Request):
     # Status filter — ignored movies are excluded from all other status views
     if status_filter == "downloaded":
         filtered_movies = [
-            m for m in filtered_movies
+            m
+            for m in filtered_movies
             if m.get("status") == "Downloaded"
             and m.get("tmdb_id") not in ignored_tmdb_ids_set
         ]
     elif status_filter == "missing":
         filtered_movies = [
-            m for m in filtered_movies
+            m
+            for m in filtered_movies
             if m.get("status") == "Missing"
             and m.get("tmdb_id") not in ignored_tmdb_ids_set
         ]
     elif status_filter == "not_in_radarr":
         filtered_movies = [
-            m for m in filtered_movies
-            if not m.get("radarr_id")
-            and m.get("tmdb_id") not in ignored_tmdb_ids_set
+            m
+            for m in filtered_movies
+            if not m.get("radarr_id") and m.get("tmdb_id") not in ignored_tmdb_ids_set
         ]
     elif status_filter == "ignored":
         filtered_movies = [
@@ -245,22 +247,30 @@ async def movie_overview_page(request: Request):
     stats = {
         "total": len(all_movies),
         "in_radarr": sum(
-            1 for m in all_movies
+            1
+            for m in all_movies
             if m.get("radarr_id") and m.get("tmdb_id") not in ignored_tmdb_ids_set
         ),
         "downloaded": sum(
-            1 for m in all_movies
-            if m.get("status") == "Downloaded" and m.get("tmdb_id") not in ignored_tmdb_ids_set
+            1
+            for m in all_movies
+            if m.get("status") == "Downloaded"
+            and m.get("tmdb_id") not in ignored_tmdb_ids_set
         ),
         "missing": sum(
-            1 for m in all_movies
-            if m.get("status") == "Missing" and m.get("tmdb_id") not in ignored_tmdb_ids_set
+            1
+            for m in all_movies
+            if m.get("status") == "Missing"
+            and m.get("tmdb_id") not in ignored_tmdb_ids_set
         ),
         "not_in_radarr": sum(
-            1 for m in all_movies
+            1
+            for m in all_movies
             if not m.get("radarr_id") and m.get("tmdb_id") not in ignored_tmdb_ids_set
         ),
-        "ignored": sum(1 for m in all_movies if m.get("tmdb_id") in ignored_tmdb_ids_set),
+        "ignored": sum(
+            1 for m in all_movies if m.get("tmdb_id") in ignored_tmdb_ids_set
+        ),
     }
 
     # Get recent weeks for quick navigation

--- a/src/api/routes/web.py
+++ b/src/api/routes/web.py
@@ -180,6 +180,11 @@ async def movie_overview_page(request: Request):
 
     # Avoid synchronous full Radarr fetch here; hydrate via AJAX on the client
 
+    # Load ignore list (needed for filtering and stats)
+    ignore_list = IgnoreList()
+    ignored_tmdb_ids_set = ignore_list.get_ignored_tmdb_ids()
+    ignored_tmdb_ids = list(ignored_tmdb_ids_set)
+
     # Apply filters
     filtered_movies = all_movies
 
@@ -192,6 +197,10 @@ async def movie_overview_page(request: Request):
         filtered_movies = [m for m in filtered_movies if m.get("status") == "Missing"]
     elif status_filter == "not_in_radarr":
         filtered_movies = [m for m in filtered_movies if not m.get("radarr_id")]
+    elif status_filter == "ignored":
+        filtered_movies = [
+            m for m in filtered_movies if m.get("tmdb_id") in ignored_tmdb_ids_set
+        ]
 
     # Year filter
     if year_filter_str and year_filter_str.isdigit():
@@ -229,15 +238,12 @@ async def movie_overview_page(request: Request):
         "downloaded": sum(1 for m in all_movies if m.get("status") == "Downloaded"),
         "missing": sum(1 for m in all_movies if m.get("status") == "Missing"),
         "not_in_radarr": sum(1 for m in all_movies if not m.get("radarr_id")),
+        "ignored": sum(1 for m in all_movies if m.get("tmdb_id") in ignored_tmdb_ids_set),
     }
 
     # Get recent weeks for quick navigation
     recent_weeks = await get_available_weeks()
     recent_weeks = recent_weeks[:5]  # Show last 5 weeks
-
-    # Load ignore list
-    ignore_list = IgnoreList()
-    ignored_tmdb_ids = list(ignore_list.get_ignored_tmdb_ids())
 
     return templates.TemplateResponse(
         "overview.html",

--- a/src/api/routes/web.py
+++ b/src/api/routes/web.py
@@ -188,15 +188,25 @@ async def movie_overview_page(request: Request):
     # Apply filters
     filtered_movies = all_movies
 
-    # Status filter
+    # Status filter — ignored movies are excluded from all other status views
     if status_filter == "downloaded":
         filtered_movies = [
-            m for m in filtered_movies if m.get("status") == "Downloaded"
+            m for m in filtered_movies
+            if m.get("status") == "Downloaded"
+            and m.get("tmdb_id") not in ignored_tmdb_ids_set
         ]
     elif status_filter == "missing":
-        filtered_movies = [m for m in filtered_movies if m.get("status") == "Missing"]
+        filtered_movies = [
+            m for m in filtered_movies
+            if m.get("status") == "Missing"
+            and m.get("tmdb_id") not in ignored_tmdb_ids_set
+        ]
     elif status_filter == "not_in_radarr":
-        filtered_movies = [m for m in filtered_movies if not m.get("radarr_id")]
+        filtered_movies = [
+            m for m in filtered_movies
+            if not m.get("radarr_id")
+            and m.get("tmdb_id") not in ignored_tmdb_ids_set
+        ]
     elif status_filter == "ignored":
         filtered_movies = [
             m for m in filtered_movies if m.get("tmdb_id") in ignored_tmdb_ids_set
@@ -231,13 +241,25 @@ async def movie_overview_page(request: Request):
 
     # Avoid per-request full-library status refresh; client will update via AJAX
 
-    # Count statistics
+    # Count statistics — ignored movies are excluded from all other buckets
     stats = {
         "total": len(all_movies),
-        "in_radarr": sum(1 for m in all_movies if m.get("radarr_id")),
-        "downloaded": sum(1 for m in all_movies if m.get("status") == "Downloaded"),
-        "missing": sum(1 for m in all_movies if m.get("status") == "Missing"),
-        "not_in_radarr": sum(1 for m in all_movies if not m.get("radarr_id")),
+        "in_radarr": sum(
+            1 for m in all_movies
+            if m.get("radarr_id") and m.get("tmdb_id") not in ignored_tmdb_ids_set
+        ),
+        "downloaded": sum(
+            1 for m in all_movies
+            if m.get("status") == "Downloaded" and m.get("tmdb_id") not in ignored_tmdb_ids_set
+        ),
+        "missing": sum(
+            1 for m in all_movies
+            if m.get("status") == "Missing" and m.get("tmdb_id") not in ignored_tmdb_ids_set
+        ),
+        "not_in_radarr": sum(
+            1 for m in all_movies
+            if not m.get("radarr_id") and m.get("tmdb_id") not in ignored_tmdb_ids_set
+        ),
         "ignored": sum(1 for m in all_movies if m.get("tmdb_id") in ignored_tmdb_ids_set),
     }
 

--- a/src/web/templates/overview.html
+++ b/src/web/templates/overview.html
@@ -495,6 +495,10 @@
                 <span class="stat-value">{{ stats.not_in_radarr }}</span>
                 <span class="stat-label">Not in Radarr</span>
             </div>
+            <div class="stat-card">
+                <span class="stat-value">{{ stats.ignored }}</span>
+                <span class="stat-label">Ignored</span>
+            </div>
         </div>
         
         <!-- Recent Weeks Quick Links -->
@@ -539,8 +543,10 @@
                    class="filter-btn {% if status_filter == 'downloaded' %}active{% endif %}">Downloaded</a>
                 <a href="?status=missing&year={{ year_filter or '' }}&search={{ search_query }}&per_page={{ per_page }}" 
                    class="filter-btn {% if status_filter == 'missing' %}active{% endif %}">Missing</a>
-                <a href="?status=not_in_radarr&year={{ year_filter or '' }}&search={{ search_query }}&per_page={{ per_page }}" 
+                <a href="?status=not_in_radarr&year={{ year_filter or '' }}&search={{ search_query }}&per_page={{ per_page }}"
                    class="filter-btn {% if status_filter == 'not_in_radarr' %}active{% endif %}">Not in Radarr</a>
+                <a href="?status=ignored&year={{ year_filter or '' }}&search={{ search_query }}&per_page={{ per_page }}"
+                   class="filter-btn {% if status_filter == 'ignored' %}active{% endif %}">Ignored</a>
             </div>
         </div>
         

--- a/src/web/templates/overview.html
+++ b/src/web/templates/overview.html
@@ -373,8 +373,8 @@
 
 .ignored-badge {
     position: absolute;
-    top: 10px;
-    right: 10px;
+    bottom: 10px;
+    left: 10px;
     background: rgba(245, 101, 101, 0.9);
     color: white;
     padding: 4px 10px;

--- a/src/web/templates/overview.html
+++ b/src/web/templates/overview.html
@@ -373,8 +373,9 @@
 
 .ignored-badge {
     position: absolute;
-    bottom: 10px;
-    left: 10px;
+    top: 10px;
+    left: 50%;
+    transform: translateX(-50%);
     background: rgba(245, 101, 101, 0.9);
     color: white;
     padding: 4px 10px;
@@ -383,6 +384,7 @@
     font-weight: 600;
     z-index: 2;
     box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+    white-space: nowrap;
 }
 
 .action-btn.ignore-btn {


### PR DESCRIPTION
## Summary

Addresses #100 and #101. Also adds `workflow_dispatch` to the CD pipeline so branch images can be manually built and tested from the Actions UI.

---

### #101 — Add Ignored to overview & status filters

- Adds a 6th **Ignored** stat card to the Movie Overview stats grid so ignored movies are clearly counted and cross-foot with the other buckets
- Adds an **Ignored** filter button alongside All / Downloaded / Missing / Not in Radarr

### #100 — Ignored tag covers week info / filter bleed

**Badge overlap fix:** `.ignored-badge` and `.week-badges` were both absolutely positioned at `top: 10px; right: 10px` on the movie card. The ignored badge was covering the week tags entirely. Moved the ignored badge to top-center (`left: 50%; transform: translateX(-50%)`) so both are always visible simultaneously.

**Filter bleed fix:** Ignored movies were surfacing inside the Missing and Not in Radarr status filters because the filter predicates only checked movie status, not the ignore list. Each non-ignored status filter now also excludes movies whose TMDB ID is in the ignore set. The stat counts are updated the same way so numbers match what the filters show.

---

## Changes

| File | What changed |
|---|---|
| `src/api/routes/web.py` | Load ignore list before filters (single pass); add `ignored` filter clause; exclude ignored from all other status filter predicates and stat counts; fix `TemplateResponse` calls to new Starlette API (`request, name, context`) |
| `src/web/templates/overview.html` | Add Ignored stat card; add Ignored filter button; reposition `.ignored-badge` to top-center |
| `.github/workflows/cd.yml` | Add `workflow_dispatch` trigger and `type=ref,event=branch` metadata tag so branch images can be manually built and tested from the Actions UI |

---

## Tested on my UnRaid instance, screenshots here:

Confirmed visuals updated and filters working

<img width="1040" height="604" alt="image" src="https://github.com/user-attachments/assets/8760d1dc-236e-4983-851c-f0ccf113589e" />

Ignore tag where weeks are present (aka the main Movie page)

<img width="619" height="451" alt="image" src="https://github.com/user-attachments/assets/a1eb738e-da44-4703-8d86-61d2f394584a" />

Ignore tag where weeks are not present (aka an individual weeks view )

<img width="516" height="587" alt="image" src="https://github.com/user-attachments/assets/c2d21a67-7258-4bc0-ba9e-c8d8bc574dd7" />

## AI Disclosure

Claude Sonnet 4.6 was used to develop this PR, I did not see any specific no AI use language for this project but apologies if I overlooked something!