### PR TITLE
refresh stored movie status from Radarr

### DIFF
--- a/src/api/routes/config.py
+++ b/src/api/routes/config.py
@@ -1,5 +1,6 @@
 """Configuration management routes."""
 
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -151,6 +152,14 @@ async def test_configuration(config: TestConfigRequest):
 async def save_configuration(config: SaveConfigRequest):
     """Save configuration to file."""
     try:
+        data_directory = Path(
+            os.getenv("BOXARR_DATA_DIRECTORY", str(settings.boxarr_data_directory))
+        )
+        config_path = data_directory / "local.yaml"
+        current_file_settings = Settings(boxarr_data_directory=data_directory)
+        if config_path.exists():
+            current_file_settings.load_from_yaml(config_path)
+
         # Validate cron expression first
         if config.boxarr_scheduler_enabled:
             try:
@@ -205,7 +214,7 @@ async def save_configuration(config: SaveConfigRequest):
         # - If field absent: preserve existing config untouched
         if config.radarr_root_folder_config is not None:
             posted = config.radarr_root_folder_config
-            current = settings.radarr_root_folder_config
+            current = current_file_settings.radarr_root_folder_config
 
             if len(posted.mappings) == 0 and len(current.mappings) > 0:
                 # Keep rules, apply posted enabled flag (allows disabling without losing rules)
@@ -236,7 +245,7 @@ async def save_configuration(config: SaveConfigRequest):
                 }
         else:
             # No root folder config provided at all - preserve existing if any
-            current_settings = settings
+            current_settings = current_file_settings
             if (
                 current_settings.radarr_root_folder_config.enabled
                 or current_settings.radarr_root_folder_config.mappings
@@ -292,7 +301,6 @@ async def save_configuration(config: SaveConfigRequest):
         }
 
         # Save to local.yaml
-        config_path = Path(settings.boxarr_data_directory) / "local.yaml"
         import yaml
 
         with open(config_path, "w") as f:

--- a/src/api/routes/config.py
+++ b/src/api/routes/config.py
@@ -203,7 +203,7 @@ async def save_configuration(config: SaveConfigRequest):
         #   - else, save exactly what was posted
         #   - Regardless, normalize each mapping's priority to its list index (0..N-1)
         # - If field absent: preserve existing config untouched
-        if config.radarr_root_folder_config:
+        if config.radarr_root_folder_config is not None:
             posted = config.radarr_root_folder_config
             current = settings.radarr_root_folder_config
 

--- a/src/api/routes/movies.py
+++ b/src/api/routes/movies.py
@@ -1,5 +1,6 @@
 """Movie management routes."""
 
+import asyncio
 import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -180,7 +181,10 @@ async def refresh_stored_status():
         if not settings.radarr_api_key:
             raise HTTPException(status_code=400, detail="Radarr not configured")
 
-        results = refresh_weekly_data_from_radarr(ignore_cache=True)
+        results = await asyncio.to_thread(
+            refresh_weekly_data_from_radarr,
+            ignore_cache=True,
+        )
         return RefreshStoredStatusResponse(
             success=True,
             message="Weekly movie data refreshed from Radarr",

--- a/src/api/routes/movies.py
+++ b/src/api/routes/movies.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 
 from ...core.ignore_list import IgnoreList
 from ...core.json_generator import WeeklyDataGenerator
+from ...core.library_sync import refresh_weekly_data_from_radarr
 from ...core.models import MovieStatus
 from ...core.radarr import RadarrService
 from ...core.root_folder_manager import RootFolderManager
@@ -43,6 +44,17 @@ class UpgradeResponse(BaseModel):
     success: bool
     message: str
     new_profile: Optional[str] = None
+
+
+class RefreshStoredStatusResponse(BaseModel):
+    """Response model for refreshing stored weekly data from Radarr."""
+
+    success: bool
+    message: str
+    weeks_scanned: int = 0
+    weeks_updated: int = 0
+    movies_refreshed: int = 0
+    movies_linked: int = 0
 
 
 class AddMovieRequest(BaseModel):
@@ -158,6 +170,29 @@ async def unignore_movie(tmdb_id: int):
         }
     except Exception as e:
         logger.error(f"Error removing from ignore list: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post("/refresh-stored-status", response_model=RefreshStoredStatusResponse)
+async def refresh_stored_status():
+    """Refresh stored weekly movie data using current Radarr state."""
+    try:
+        if not settings.radarr_api_key:
+            raise HTTPException(status_code=400, detail="Radarr not configured")
+
+        results = refresh_weekly_data_from_radarr(ignore_cache=True)
+        return RefreshStoredStatusResponse(
+            success=True,
+            message="Weekly movie data refreshed from Radarr",
+            weeks_scanned=results.get("weeks_scanned", 0),
+            weeks_updated=results.get("weeks_updated", 0),
+            movies_refreshed=results.get("movies_refreshed", 0),
+            movies_linked=results.get("movies_linked", 0),
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error refreshing stored weekly data: {e}")
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/src/api/routes/movies.py
+++ b/src/api/routes/movies.py
@@ -11,7 +11,7 @@ from ...core.ignore_list import IgnoreList
 from ...core.json_generator import WeeklyDataGenerator
 from ...core.library_sync import refresh_weekly_data_from_radarr
 from ...core.models import MovieStatus
-from ...core.radarr import RadarrService
+from ...core.radarr import RadarrService, get_all_movies_with_optional_cache_bypass
 from ...core.root_folder_manager import RootFolderManager
 from ...utils.config import settings
 from ...utils.logger import get_logger
@@ -400,7 +400,9 @@ async def add_movie_to_radarr(request: AddMovieRequest):
 
         # Before adding, check if this TMDB ID already exists in Radarr (fresh library)
         try:
-            existing_movies = radarr_service.get_all_movies(ignore_cache=True)
+            existing_movies = get_all_movies_with_optional_cache_bypass(
+                radarr_service, ignore_cache=True
+            )
             tmdb_id = (
                 int(movie_data.get("tmdbId")) if movie_data.get("tmdbId") else None
             )
@@ -491,7 +493,9 @@ def regenerate_weeks_with_movie(movie_title: str):
 
     # Get updated Radarr library
     # Always bypass cache so recently added movies are visible to the matcher
-    radarr_movies = radarr_service.get_all_movies(ignore_cache=True)
+    radarr_movies = get_all_movies_with_optional_cache_bypass(
+        radarr_service, ignore_cache=True
+    )
 
     # Search all metadata files
     for json_file in weekly_pages_dir.glob("*.json"):

--- a/src/api/routes/scheduler.py
+++ b/src/api/routes/scheduler.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from ...core.scheduler import BoxarrScheduler
+from ...core.radarr import RadarrService, get_all_movies_with_optional_cache_bypass
 from ...utils.config import settings
 from ...utils.logger import get_logger
 
@@ -24,7 +25,6 @@ def get_scheduler() -> BoxarrScheduler:
     global _scheduler
     if not _scheduler:
         from ...core.boxoffice import BoxOfficeService
-        from ...core.radarr import RadarrService
 
         _scheduler = BoxarrScheduler(
             boxoffice_service=BoxOfficeService(),
@@ -272,8 +272,6 @@ async def update_specific_week(request: UpdateWeekRequest):  # noqa: C901
         from ...core.boxoffice import BoxOfficeService
         from ...core.json_generator import WeeklyDataGenerator
         from ...core.matcher import MovieMatcher
-        from ...core.radarr import RadarrService
-
         # Get box office data
         boxoffice_service = BoxOfficeService()
         limit = settings.boxarr_features_box_office_limit
@@ -295,7 +293,9 @@ async def update_specific_week(request: UpdateWeekRequest):  # noqa: C901
             radarr_service = RadarrService()
             matcher = MovieMatcher()
 
-            radarr_movies = radarr_service.get_all_movies(ignore_cache=True)
+            radarr_movies = get_all_movies_with_optional_cache_bypass(
+                radarr_service, ignore_cache=True
+            )
             matcher.build_movie_index(radarr_movies)
             match_results = matcher.match_movies(box_office_movies, radarr_movies)
 
@@ -311,7 +311,9 @@ async def update_specific_week(request: UpdateWeekRequest):  # noqa: C901
                 # Re-fetch and re-match after adding (fixes stale status bug)
                 if added_count > 0:
                     logger.info(f"Added {added_count} movies to Radarr, re-matching...")
-                    radarr_movies = radarr_service.get_all_movies(ignore_cache=True)
+                    radarr_movies = get_all_movies_with_optional_cache_bypass(
+                        radarr_service, ignore_cache=True
+                    )
                     matcher.build_movie_index(radarr_movies)
                     match_results = matcher.match_movies(
                         box_office_movies, radarr_movies

--- a/src/api/routes/scheduler.py
+++ b/src/api/routes/scheduler.py
@@ -295,7 +295,7 @@ async def update_specific_week(request: UpdateWeekRequest):  # noqa: C901
             radarr_service = RadarrService()
             matcher = MovieMatcher()
 
-            radarr_movies = radarr_service.get_all_movies()
+            radarr_movies = radarr_service.get_all_movies(ignore_cache=True)
             matcher.build_movie_index(radarr_movies)
             match_results = matcher.match_movies(box_office_movies, radarr_movies)
 
@@ -311,7 +311,7 @@ async def update_specific_week(request: UpdateWeekRequest):  # noqa: C901
                 # Re-fetch and re-match after adding (fixes stale status bug)
                 if added_count > 0:
                     logger.info(f"Added {added_count} movies to Radarr, re-matching...")
-                    radarr_movies = radarr_service.get_all_movies()
+                    radarr_movies = radarr_service.get_all_movies(ignore_cache=True)
                     matcher.build_movie_index(radarr_movies)
                     match_results = matcher.match_movies(
                         box_office_movies, radarr_movies

--- a/src/api/routes/scheduler.py
+++ b/src/api/routes/scheduler.py
@@ -9,7 +9,6 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from ...core.scheduler import BoxarrScheduler
-from ...core.radarr import RadarrService, get_all_movies_with_optional_cache_bypass
 from ...utils.config import settings
 from ...utils.logger import get_logger
 
@@ -25,6 +24,7 @@ def get_scheduler() -> BoxarrScheduler:
     global _scheduler
     if not _scheduler:
         from ...core.boxoffice import BoxOfficeService
+        from ...core.radarr import RadarrService
 
         _scheduler = BoxarrScheduler(
             boxoffice_service=BoxOfficeService(),
@@ -272,6 +272,11 @@ async def update_specific_week(request: UpdateWeekRequest):  # noqa: C901
         from ...core.boxoffice import BoxOfficeService
         from ...core.json_generator import WeeklyDataGenerator
         from ...core.matcher import MovieMatcher
+        from ...core.radarr import (
+            RadarrService,
+            get_all_movies_with_optional_cache_bypass,
+        )
+
         # Get box office data
         boxoffice_service = BoxOfficeService()
         limit = settings.boxarr_features_box_office_limit

--- a/src/core/library_sync.py
+++ b/src/core/library_sync.py
@@ -8,7 +8,11 @@ from typing import Any, Dict, Optional
 from ..utils.config import settings
 from ..utils.logger import get_logger
 from .models import MovieStatus
-from .radarr import RadarrMovie, RadarrService
+from .radarr import (
+    RadarrMovie,
+    RadarrService,
+    get_all_movies_with_optional_cache_bypass,
+)
 
 logger = get_logger(__name__)
 
@@ -74,7 +78,9 @@ def refresh_weekly_data_from_radarr(
     ignore_cache: bool = False,
 ) -> Dict[str, int]:
     """Refresh stored weekly JSON files with current Radarr status/details."""
-    weekly_pages_dir = (data_directory or settings.boxarr_data_directory) / "weekly_pages"
+    weekly_pages_dir = (
+        data_directory or settings.boxarr_data_directory
+    ) / "weekly_pages"
     if not weekly_pages_dir.exists():
         return {
             "weeks_scanned": 0,
@@ -84,7 +90,7 @@ def refresh_weekly_data_from_radarr(
         }
 
     service = radarr_service or RadarrService()
-    radarr_movies = service.get_all_movies(ignore_cache=ignore_cache)
+    radarr_movies = get_all_movies_with_optional_cache_bypass(service, ignore_cache)
     profiles = service.get_quality_profiles()
     profiles_by_id = {profile.id: profile.name for profile in profiles}
     upgrade_profile_id = next(

--- a/src/core/library_sync.py
+++ b/src/core/library_sync.py
@@ -1,0 +1,166 @@
+"""Helpers for refreshing stored weekly movie data from Radarr."""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from ..utils.config import settings
+from ..utils.logger import get_logger
+from .models import MovieStatus
+from .radarr import RadarrMovie, RadarrService
+
+logger = get_logger(__name__)
+
+
+def _truncate_overview(overview: Optional[str]) -> Optional[str]:
+    """Truncate overview text to match stored JSON shape."""
+    if not overview:
+        return overview
+    return overview[:150] + "..." if len(overview) > 150 else overview
+
+
+def _build_movie_update(
+    movie: RadarrMovie,
+    profiles_by_id: Dict[int, str],
+    upgrade_profile_id: Optional[int],
+) -> Dict[str, Any]:
+    """Build the persisted JSON fields for a Radarr-backed movie."""
+    if movie.hasFile:
+        display_status = "Downloaded"
+        status_color = "#48bb78"
+        status_icon = "✅"
+    elif movie.status == MovieStatus.RELEASED and getattr(movie, "isAvailable", False):
+        display_status = "Missing"
+        status_color = "#f56565"
+        status_icon = "❌"
+    elif movie.status == MovieStatus.IN_CINEMAS:
+        display_status = "In Cinemas"
+        status_color = "#f6ad55"
+        status_icon = "🎬"
+    else:
+        display_status = "Pending"
+        status_color = "#ed8936"
+        status_icon = "⏳"
+
+    return {
+        "radarr_id": movie.id,
+        "radarr_title": movie.title,
+        "status": display_status,
+        "status_color": status_color,
+        "status_icon": status_icon,
+        "quality_profile_id": movie.qualityProfileId,
+        "quality_profile_name": profiles_by_id.get(movie.qualityProfileId or -1, ""),
+        "has_file": movie.hasFile,
+        "can_upgrade_quality": bool(
+            settings.boxarr_features_quality_upgrade
+            and movie.qualityProfileId is not None
+            and upgrade_profile_id is not None
+            and movie.qualityProfileId != upgrade_profile_id
+        ),
+        "year": movie.year,
+        "genres": ", ".join(movie.genres[:2]) if movie.genres else None,
+        "overview": _truncate_overview(movie.overview),
+        "imdb_id": movie.imdbId,
+        "tmdb_id": movie.tmdbId,
+        "original_language": movie.original_language,
+        "poster": movie.poster_url,
+    }
+
+
+def refresh_weekly_data_from_radarr(
+    radarr_service: Optional[RadarrService] = None,
+    data_directory: Optional[Path] = None,
+    ignore_cache: bool = False,
+) -> Dict[str, int]:
+    """Refresh stored weekly JSON files with current Radarr status/details."""
+    weekly_pages_dir = (data_directory or settings.boxarr_data_directory) / "weekly_pages"
+    if not weekly_pages_dir.exists():
+        return {
+            "weeks_scanned": 0,
+            "weeks_updated": 0,
+            "movies_refreshed": 0,
+            "movies_linked": 0,
+        }
+
+    service = radarr_service or RadarrService()
+    radarr_movies = service.get_all_movies(ignore_cache=ignore_cache)
+    profiles = service.get_quality_profiles()
+    profiles_by_id = {profile.id: profile.name for profile in profiles}
+    upgrade_profile_id = next(
+        (
+            profile.id
+            for profile in profiles
+            if profile.name == settings.radarr_quality_profile_upgrade
+        ),
+        None,
+    )
+
+    movies_by_id = {movie.id: movie for movie in radarr_movies}
+    movies_by_tmdb_id = {movie.tmdbId: movie for movie in radarr_movies if movie.tmdbId}
+
+    weeks_scanned = 0
+    weeks_updated = 0
+    movies_refreshed = 0
+    movies_linked = 0
+
+    for json_file in sorted(weekly_pages_dir.glob("*.json")):
+        if json_file.name == "current.json":
+            continue
+
+        weeks_scanned += 1
+
+        try:
+            with open(json_file) as f:
+                data = json.load(f)
+        except Exception as exc:
+            logger.warning(f"Could not read weekly data file {json_file}: {exc}")
+            continue
+
+        file_updated = False
+        for stored_movie in data.get("movies", []):
+            radarr_movie = None
+            existing_radarr_id = stored_movie.get("radarr_id")
+            stored_tmdb_id = stored_movie.get("tmdb_id")
+
+            if existing_radarr_id:
+                radarr_movie = movies_by_id.get(existing_radarr_id)
+
+            if not radarr_movie and stored_tmdb_id:
+                radarr_movie = movies_by_tmdb_id.get(stored_tmdb_id)
+
+            if not radarr_movie:
+                continue
+
+            was_unmatched = not existing_radarr_id
+            updates = _build_movie_update(
+                radarr_movie, profiles_by_id, upgrade_profile_id
+            )
+
+            changed = False
+            for key, value in updates.items():
+                if stored_movie.get(key) != value:
+                    stored_movie[key] = value
+                    changed = True
+
+            if changed:
+                movies_refreshed += 1
+                file_updated = True
+                if was_unmatched and stored_movie.get("radarr_id"):
+                    movies_linked += 1
+
+        if file_updated:
+            data["matched_movies"] = sum(
+                1 for movie in data.get("movies", []) if movie.get("radarr_id")
+            )
+            data["status_refreshed_at"] = datetime.now().isoformat()
+            with open(json_file, "w") as f:
+                json.dump(data, f, indent=2, default=str)
+            weeks_updated += 1
+
+    return {
+        "weeks_scanned": weeks_scanned,
+        "weeks_updated": weeks_updated,
+        "movies_refreshed": movies_refreshed,
+        "movies_linked": movies_linked,
+    }

--- a/src/core/radarr.py
+++ b/src/core/radarr.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass, field
 from enum import Enum
+from inspect import signature
 from typing import Any, Dict, List, Optional, cast
 
 import httpx
@@ -91,6 +92,24 @@ class RadarrMovie:
 
 _movies_cache: Dict[str, Any] = {"ts": 0.0, "data": []}
 _profiles_cache: Dict[str, Any] = {"ts": 0.0, "data": []}
+
+
+def get_all_movies_with_optional_cache_bypass(
+    radarr_service: Any, ignore_cache: bool = False
+) -> List[RadarrMovie]:
+    """Fetch movies while tolerating test doubles without ``ignore_cache`` support."""
+    get_all_movies = radarr_service.get_all_movies
+
+    if not ignore_cache:
+        return cast(List[RadarrMovie], get_all_movies())
+
+    try:
+        if "ignore_cache" in signature(get_all_movies).parameters:
+            return cast(List[RadarrMovie], get_all_movies(ignore_cache=True))
+    except (TypeError, ValueError):
+        pass
+
+    return cast(List[RadarrMovie], get_all_movies())
 
 
 class RadarrService:

--- a/src/core/scheduler.py
+++ b/src/core/scheduler.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
+from functools import partial
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
@@ -237,10 +238,11 @@ class BoxarrScheduler:
 
             # Refresh all stored weekly pages against current Radarr status/details.
             refresh_results = await self._run_in_executor(
-                refresh_weekly_data_from_radarr,
-                self.radarr_service,
-                None,
-                True,
+                partial(
+                    refresh_weekly_data_from_radarr,
+                    radarr_service=self.radarr_service,
+                    ignore_cache=True,
+                )
             )
             logger.info(
                 "Refreshed weekly data from Radarr: %s weeks updated, %s movies refreshed, %s movies linked",

--- a/src/core/scheduler.py
+++ b/src/core/scheduler.py
@@ -18,6 +18,7 @@ from .auto_add import auto_add_missing_movies
 from .boxoffice import BoxOfficeService
 from .exceptions import SchedulerError
 from .json_generator import WeeklyDataGenerator
+from .library_sync import refresh_weekly_data_from_radarr
 from .matcher import MatchResult, MovieMatcher
 from .models import MovieStatus
 from .radarr import RadarrService
@@ -176,7 +177,8 @@ class BoxarrScheduler:
 
             # Fetch Radarr movies
             radarr_movies = await self._run_in_executor(
-                self.radarr_service.get_all_movies
+                self.radarr_service.get_all_movies,
+                True,
             )
 
             # Match movies
@@ -204,7 +206,8 @@ class BoxarrScheduler:
                     f"Added {len(added_movies)} movies to Radarr, re-matching..."
                 )
                 radarr_movies = await self._run_in_executor(
-                    self.radarr_service.get_all_movies
+                    self.radarr_service.get_all_movies,
+                    True,
                 )
                 match_results = await self._run_in_executor(
                     self.matcher.match_batch, box_office_movies, radarr_movies
@@ -230,10 +233,25 @@ class BoxarrScheduler:
                 actual_week,
             )
 
+            # Refresh all stored weekly pages against current Radarr status/details.
+            refresh_results = await self._run_in_executor(
+                refresh_weekly_data_from_radarr,
+                self.radarr_service,
+                None,
+                True,
+            )
+            logger.info(
+                "Refreshed weekly data from Radarr: %s weeks updated, %s movies refreshed, %s movies linked",
+                refresh_results.get("weeks_updated", 0),
+                refresh_results.get("movies_refreshed", 0),
+                refresh_results.get("movies_linked", 0),
+            )
+
             # Process results for history
             results = self._process_match_results(match_results)
             results["data_path"] = str(data_path)
             results["added_movies"] = added_movies
+            results["status_refresh"] = refresh_results
 
             # Save to history
             await self._save_to_history(results, actual_year, actual_week)

--- a/src/core/scheduler.py
+++ b/src/core/scheduler.py
@@ -21,7 +21,7 @@ from .json_generator import WeeklyDataGenerator
 from .library_sync import refresh_weekly_data_from_radarr
 from .matcher import MatchResult, MovieMatcher
 from .models import MovieStatus
-from .radarr import RadarrService
+from .radarr import RadarrService, get_all_movies_with_optional_cache_bypass
 
 logger = get_logger(__name__)
 
@@ -177,7 +177,8 @@ class BoxarrScheduler:
 
             # Fetch Radarr movies
             radarr_movies = await self._run_in_executor(
-                self.radarr_service.get_all_movies,
+                get_all_movies_with_optional_cache_bypass,
+                self.radarr_service,
                 True,
             )
 
@@ -206,7 +207,8 @@ class BoxarrScheduler:
                     f"Added {len(added_movies)} movies to Radarr, re-matching..."
                 )
                 radarr_movies = await self._run_in_executor(
-                    self.radarr_service.get_all_movies,
+                    get_all_movies_with_optional_cache_bypass,
+                    self.radarr_service,
                     True,
                 )
                 match_results = await self._run_in_executor(

--- a/src/web/static/js/app.js
+++ b/src/web/static/js/app.js
@@ -1600,6 +1600,44 @@ function reloadScheduler() {
         loadAvailableRootFolders(true);
     };
 
+    window.refreshStoredMovieStatuses = async function (buttonEl) {
+        const originalText = buttonEl ? buttonEl.textContent : 'Refresh Radarr Status';
+
+        if (buttonEl) {
+            buttonEl.disabled = true;
+            buttonEl.textContent = 'Refreshing...';
+        }
+
+        try {
+            const response = await fetch(apiUrl('/movies/refresh-stored-status'), {
+                method: 'POST'
+            });
+            const data = await response.json();
+
+            if (!response.ok || !data.success) {
+                throw new Error(data.detail || data.message || 'Failed to refresh movie data');
+            }
+
+            showMessage(
+                `Refreshed ${data.movies_refreshed || 0} movie entries across ${data.weeks_updated || 0} weeks`,
+                'success'
+            );
+            setTimeout(() => window.location.reload(), 800);
+        } catch (error) {
+            showMessage('Failed to refresh stored movie data: ' + error.message, 'error');
+            if (buttonEl) {
+                buttonEl.disabled = false;
+                buttonEl.textContent = originalText;
+            }
+            return;
+        }
+
+        if (buttonEl) {
+            buttonEl.disabled = false;
+            buttonEl.textContent = originalText;
+        }
+    };
+
     // Toggle ignore status for a movie
     window.toggleIgnore = async function (tmdbId, title, buttonEl) {
         if (!tmdbId) return;

--- a/src/web/templates/overview.html
+++ b/src/web/templates/overview.html
@@ -92,6 +92,12 @@
     gap: 0.5rem;
 }
 
+.overview-actions {
+    display: flex;
+    align-items: end;
+    margin-left: auto;
+}
+
 .filter-btn {
     padding: 0.5rem 1rem;
     border: 1px solid var(--border-color);
@@ -550,6 +556,12 @@
                 <a href="?status=ignored&year={{ year_filter or '' }}&search={{ search_query }}&per_page={{ per_page }}"
                    class="filter-btn {% if status_filter == 'ignored' %}active{% endif %}">Ignored</a>
             </div>
+        </div>
+
+        <div class="overview-actions">
+            <button type="button" class="filter-btn" onclick="refreshStoredMovieStatuses(this)">
+                Refresh Radarr Status
+            </button>
         </div>
         
         <div class="filter-group">

--- a/src/web/templates/overview.html
+++ b/src/web/templates/overview.html
@@ -94,7 +94,7 @@
 
 .overview-actions {
     display: flex;
-    align-items: end;
+    align-items: flex-end;
     margin-left: auto;
 }
 

--- a/tests/unit/test_library_sync.py
+++ b/tests/unit/test_library_sync.py
@@ -1,0 +1,175 @@
+"""Tests for refreshing stored weekly data from Radarr."""
+
+import json
+
+from src.core.library_sync import refresh_weekly_data_from_radarr
+from src.core.models import MovieStatus
+
+
+class _FakeProfile:
+    def __init__(self, profile_id: int, name: str):
+        self.id = profile_id
+        self.name = name
+
+
+class _FakeMovie:
+    def __init__(
+        self,
+        movie_id: int,
+        tmdb_id: int,
+        title: str,
+        *,
+        has_file: bool,
+        status: MovieStatus,
+        is_available: bool,
+        quality_profile_id: int,
+        poster_url: str,
+    ):
+        self.id = movie_id
+        self.tmdbId = tmdb_id
+        self.title = title
+        self.hasFile = has_file
+        self.status = status
+        self.isAvailable = is_available
+        self.qualityProfileId = quality_profile_id
+        self.poster_url = poster_url
+        self.year = 2024
+        self.genres = ["Action", "Adventure"]
+        self.overview = f"{title} overview"
+        self.imdbId = f"tt{movie_id}"
+        self.original_language = "English"
+
+
+class _FakeRadarrService:
+    def __init__(self, movies, profiles):
+        self._movies = movies
+        self._profiles = profiles
+        self.ignore_cache_calls = []
+
+    def get_all_movies(self, ignore_cache: bool = False):
+        self.ignore_cache_calls.append(ignore_cache)
+        return self._movies
+
+    def get_quality_profiles(self):
+        return self._profiles
+
+
+def test_refresh_weekly_data_from_radarr_updates_stale_entries(tmp_path, monkeypatch):
+    weekly_pages_dir = tmp_path / "weekly_pages"
+    weekly_pages_dir.mkdir()
+
+    week_file = weekly_pages_dir / "2024W10.json"
+    with open(week_file, "w") as f:
+        json.dump(
+            {
+                "generated_at": "2026-04-05T10:00:00",
+                "year": 2024,
+                "week": 10,
+                "matched_movies": 1,
+                "movies": [
+                    {
+                        "title": "Downloaded Later",
+                        "radarr_id": 101,
+                        "tmdb_id": 1001,
+                        "status": "Missing",
+                        "status_color": "#f56565",
+                        "status_icon": "❌",
+                        "quality_profile_id": 1,
+                        "quality_profile_name": "HD-1080p",
+                        "has_file": False,
+                        "can_upgrade_quality": False,
+                        "poster": None,
+                        "year": 2024,
+                        "genres": None,
+                        "overview": None,
+                        "imdb_id": None,
+                        "original_language": None,
+                    },
+                    {
+                        "title": "Linked From TMDB",
+                        "radarr_id": None,
+                        "tmdb_id": 1002,
+                        "status": "Not in Radarr",
+                        "status_color": "#718096",
+                        "status_icon": "➕",
+                        "quality_profile_id": None,
+                        "quality_profile_name": None,
+                        "has_file": False,
+                        "can_upgrade_quality": False,
+                        "poster": None,
+                        "year": 2024,
+                        "genres": None,
+                        "overview": None,
+                        "imdb_id": None,
+                        "original_language": None,
+                    },
+                ],
+            },
+            f,
+            indent=2,
+        )
+
+    monkeypatch.setattr(
+        "src.core.library_sync.settings.boxarr_features_quality_upgrade", True
+    )
+    monkeypatch.setattr(
+        "src.core.library_sync.settings.radarr_quality_profile_upgrade", "Ultra-HD"
+    )
+
+    fake_service = _FakeRadarrService(
+        movies=[
+            _FakeMovie(
+                101,
+                1001,
+                "Downloaded Later",
+                has_file=True,
+                status=MovieStatus.RELEASED,
+                is_available=True,
+                quality_profile_id=1,
+                poster_url="https://example.com/101.jpg",
+            ),
+            _FakeMovie(
+                202,
+                1002,
+                "Linked From TMDB",
+                has_file=False,
+                status=MovieStatus.RELEASED,
+                is_available=True,
+                quality_profile_id=1,
+                poster_url="https://example.com/202.jpg",
+            ),
+        ],
+        profiles=[_FakeProfile(1, "HD-1080p"), _FakeProfile(2, "Ultra-HD")],
+    )
+
+    results = refresh_weekly_data_from_radarr(
+        radarr_service=fake_service,
+        data_directory=tmp_path,
+        ignore_cache=True,
+    )
+
+    assert fake_service.ignore_cache_calls == [True]
+    assert results == {
+        "weeks_scanned": 1,
+        "weeks_updated": 1,
+        "movies_refreshed": 2,
+        "movies_linked": 1,
+    }
+
+    with open(week_file) as f:
+        refreshed = json.load(f)
+
+    downloaded = refreshed["movies"][0]
+    assert downloaded["status"] == "Downloaded"
+    assert downloaded["has_file"] is True
+    assert downloaded["radarr_id"] == 101
+    assert downloaded["quality_profile_name"] == "HD-1080p"
+
+    linked = refreshed["movies"][1]
+    assert linked["radarr_id"] == 202
+    assert linked["status"] == "Missing"
+    assert linked["can_upgrade_quality"] is True
+    assert linked["poster"] == "https://example.com/202.jpg"
+
+    assert refreshed["matched_movies"] == 2
+    assert "status_refreshed_at" in refreshed


### PR DESCRIPTION
## Summary

Closes #99.

This PR adds a real Radarr-to-Boxarr status refresh path for stored weekly movie data, instead of only updating the currently rendered cards in the browser.

## What Changed

- added a reusable weekly-data sync helper that refreshes persisted `weekly_pages/*.json` entries from current Radarr state
- wired the scheduler to refresh stored weekly pages after update runs so historical weeks stay in sync over time
- added a manual `Refresh Radarr Status` action on the Movies overview page
- added a focused unit test for the stored-data refresh helper
- tightened scheduler refresh/rematch paths to bypass the shared Radarr movie cache

## Root Cause

The Movies overview filters and counts are built from stored weekly JSON data, while the existing client-side status hydration only refreshed the cards already on screen. Once a movie was later downloaded in Radarr, historical week files still contained stale `Missing` state, so the overview filter logic kept surfacing those entries as missing until the specific week data was regenerated.

## Impact

- downloaded movies can now be removed from stale `Missing` overview results without regenerating each historical week manually
- scheduler-driven updates now refresh old stored week data as part of normal operation
- users have an on-demand refresh button when they want Boxarr to resync against Radarr immediately


