### PR TITLE
fix: make Ignore/Unignore buttons clickable on Overview page

### DIFF
--- a/src/web/templates/overview.html
+++ b/src/web/templates/overview.html
@@ -695,10 +695,10 @@
                     {% endif %}
 
                     {% if movie.tmdb_id %}
-                    <button class="action-btn ignore-btn" {% if is_ignored %}style="display:none"{% endif %} onclick="toggleIgnore({{ movie.tmdb_id }}, {{ movie.title|tojson }}, this)">
+                    <button class="action-btn ignore-btn" {% if is_ignored %}style="display:none"{% endif %} onclick='toggleIgnore({{ movie.tmdb_id }}, {{ movie.title|tojson }}, this)'>
                         Ignore
                     </button>
-                    <button class="action-btn unignore-btn" {% if not is_ignored %}style="display:none"{% endif %} onclick="toggleIgnore({{ movie.tmdb_id }}, {{ movie.title|tojson }}, this)">
+                    <button class="action-btn unignore-btn" {% if not is_ignored %}style="display:none"{% endif %} onclick='toggleIgnore({{ movie.tmdb_id }}, {{ movie.title|tojson }}, this)'>
                         Unignore
                     </button>
                     {% endif %}

--- a/tests/unit/test_template_onclick_quoting.py
+++ b/tests/unit/test_template_onclick_quoting.py
@@ -1,0 +1,28 @@
+"""Unit tests for onclick attribute quoting in HTML templates.
+
+Regression tests for issue #106: an onclick attribute that embeds a
+``|tojson`` value must be single-quoted, because ``tojson`` emits literal
+double quotes that would otherwise terminate a double-quoted attribute early
+and leave the button without a click handler.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+TEMPLATE_DIR = Path(__file__).resolve().parents[2] / "src" / "web" / "templates"
+
+# Matches a double-quoted onclick attribute whose value contains "|tojson".
+BAD_ONCLICK = re.compile(r'onclick="[^"]*\|tojson[^"]*"')
+
+
+@pytest.mark.parametrize("template_name", ["overview.html", "weekly.html"])
+def test_tojson_onclick_is_single_quoted(template_name):
+    """Every onclick containing |tojson must be single-quoted, not double."""
+    content = (TEMPLATE_DIR / template_name).read_text(encoding="utf-8")
+    offenders = BAD_ONCLICK.findall(content)
+    assert not offenders, (
+        f"{template_name} has double-quoted onclick with |tojson "
+        f"(breaks the handler): {offenders}"
+    )


### PR DESCRIPTION
## Problem

On the Overview page, the **Ignore** and **Unignore** buttons were unclickable. Hovering still showed the CSS hover state, but clicking did nothing — the buttons had no working click handler.

## Root Cause

In `src/web/templates/overview.html` (lines 698 and 701), both buttons used a **double-quoted** `onclick` attribute wrapping `{{ movie.title|tojson }}`. Jinja2's `tojson` filter emits literal double quotes around the string, which terminated the HTML attribute early and stripped the click handler from the element. (`tojson` HTML-escapes single quotes within string content, so a single-quoted attribute is safe.)

## Change

Changed only the quote character on those two `onclick` attributes from double to single quotes — exactly matching the already-working style used by the add-to-radarr button at `overview.html:688` and the buttons in `weekly.html`. Nothing else on those lines changed.

This extracts the same 2-line quoting fix already staged in the unmerged PR #105 (credit to xFlawless11x), so the bug fix can land independently of that PR's unrelated UI polish.

## Testing

- Added a focused regression test `tests/unit/test_template_onclick_quoting.py` that reads `overview.html` and `weekly.html` and asserts (via regex, no template rendering) that no double-quoted `onclick` attribute contains `|tojson`. Parametrized over both templates.
- Full suite: `129 passed, 1 skipped` (up from 127 + 1 on main — exactly the 2 new test cases, no regressions).
- `black --check` clean on the touched test file.

Fixes #106

