### PR TITLE
feat: add selectable Box Office Mojo region

### DIFF
--- a/src/api/routes/config.py
+++ b/src/api/routes/config.py
@@ -53,6 +53,8 @@ class SaveConfigRequest(BaseModel):
     boxarr_features_quality_upgrade: bool = True
     # Box office fetch limit
     boxarr_features_box_office_limit: int = 10
+    # Box office region (BOM area code; "" means US & Canada domestic)
+    boxarr_features_box_office_region: str = ""
     # New auto-add advanced options
     boxarr_features_auto_add_limit: int = 10
     boxarr_features_auto_add_genre_filter_enabled: bool = False
@@ -277,6 +279,7 @@ async def save_configuration(config: SaveConfigRequest):
                     "auto_add": config.boxarr_features_auto_add,
                     "quality_upgrade": config.boxarr_features_quality_upgrade,
                     "box_office_limit": config.boxarr_features_box_office_limit,
+                    "box_office_region": config.boxarr_features_box_office_region,
                     "auto_tag_enabled": config.boxarr_features_auto_tag_enabled,
                     "auto_tag_text": config.boxarr_features_auto_tag_text,
                     "auto_add_options": {

--- a/src/api/routes/web.py
+++ b/src/api/routes/web.py
@@ -11,6 +11,7 @@ from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel
 
 from ... import __version__
+from ...core.boxoffice import BOX_OFFICE_REGIONS
 from ...core.ignore_list import IgnoreList
 from ...core.models import MovieStatus
 from ...utils.config import settings
@@ -527,6 +528,9 @@ async def setup_page(request: Request):
             quality_upgrade=settings.boxarr_features_quality_upgrade,
             # Box office fetch limit
             box_office_limit=settings.boxarr_features_box_office_limit,
+            # Box office region
+            box_office_region=settings.boxarr_features_box_office_region,
+            box_office_regions=BOX_OFFICE_REGIONS,
             # Auto tagging
             auto_tag_enabled=settings.boxarr_features_auto_tag_enabled,
             auto_tag_text=settings.boxarr_features_auto_tag_text,

--- a/src/core/boxoffice.py
+++ b/src/core/boxoffice.py
@@ -8,10 +8,100 @@ from typing import Dict, List, Optional, Tuple
 import httpx
 from bs4 import BeautifulSoup
 
+from ..utils.config import settings
 from ..utils.logger import get_logger
 from .exceptions import BoxOfficeError
 
 logger = get_logger(__name__)
+
+# Box Office Mojo international "area" codes mapped to display names.
+# The empty code selects the default US & Canada domestic chart, which is
+# fetched without an ?area parameter. All other codes append ?area=CODE.
+BOX_OFFICE_REGIONS: List[Tuple[str, str]] = [
+    ("", "Domestic (US & Canada)"),
+    ("AL", "Albania"),
+    ("AR", "Argentina"),
+    ("AU", "Australia"),
+    ("AT", "Austria"),
+    ("BH", "Bahrain"),
+    ("BD", "Bangladesh"),
+    ("BE", "Belgium"),
+    ("BO", "Bolivia"),
+    ("BA", "Bosnia and Herzegovina"),
+    ("BR", "Brazil"),
+    ("BG", "Bulgaria"),
+    ("CA", "Canada"),
+    ("CL", "Chile"),
+    ("CN", "China"),
+    ("CO", "Colombia"),
+    ("CR", "Costa Rica"),
+    ("HR", "Croatia"),
+    ("CY", "Cyprus"),
+    ("CZ", "Czech Republic"),
+    ("DK", "Denmark"),
+    ("DO", "Dominican Republic"),
+    ("EC", "Ecuador"),
+    ("EG", "Egypt"),
+    ("SV", "El Salvador"),
+    ("EE", "Estonia"),
+    ("FI", "Finland"),
+    ("FR", "France"),
+    ("DE", "Germany"),
+    ("GR", "Greece"),
+    ("GT", "Guatemala"),
+    ("HK", "Hong Kong"),
+    ("HU", "Hungary"),
+    ("IS", "Iceland"),
+    ("IN", "India"),
+    ("ID", "Indonesia"),
+    ("IQ", "Iraq"),
+    ("IL", "Israel"),
+    ("IT", "Italy"),
+    ("JP", "Japan"),
+    ("JO", "Jordan"),
+    ("KE", "Kenya"),
+    ("LV", "Latvia"),
+    ("LB", "Lebanon"),
+    ("LT", "Lithuania"),
+    ("MY", "Malaysia"),
+    ("MX", "Mexico"),
+    ("MN", "Mongolia"),
+    ("NL", "Netherlands"),
+    ("NZ", "New Zealand"),
+    ("NG", "Nigeria"),
+    ("MK", "North Macedonia"),
+    ("NO", "Norway"),
+    ("OM", "Oman"),
+    ("PK", "Pakistan"),
+    ("PA", "Panama"),
+    ("PY", "Paraguay"),
+    ("PE", "Peru"),
+    ("PH", "Philippines"),
+    ("PL", "Poland"),
+    ("PT", "Portugal"),
+    ("QA", "Qatar"),
+    ("RO", "Romania"),
+    ("SA", "Saudi Arabia"),
+    ("SG", "Singapore"),
+    ("SK", "Slovakia"),
+    ("SI", "Slovenia"),
+    ("ZA", "South Africa"),
+    ("KR", "South Korea"),
+    ("ES", "Spain"),
+    ("LK", "Sri Lanka"),
+    ("SE", "Sweden"),
+    ("CH", "Switzerland"),
+    ("TW", "Taiwan"),
+    ("TH", "Thailand"),
+    ("TT", "Trinidad & Tobago"),
+    ("TR", "Türkiye"),
+    ("UA", "Ukraine"),
+    ("AE", "United Arab Emirates"),
+    ("GB", "United Kingdom"),
+    ("UY", "Uruguay"),
+    ("VE", "Venezuela"),
+    ("VN", "Vietnam"),
+]
 
 
 @dataclass
@@ -143,6 +233,25 @@ class BoxOfficeService:
         except (ValueError, AttributeError):
             return None
 
+    def _build_weekend_url(self, year: int, week: int) -> str:
+        """
+        Build the Box Office Mojo weekend URL for the configured region.
+
+        Args:
+            year: Year
+            week: ISO week number
+
+        Returns:
+            Weekend chart URL, with ?area=CODE appended for non-domestic regions
+        """
+        url = f"{self.BASE_URL}/weekend/{year}W{week:02d}/"
+        region = (
+            getattr(settings, "boxarr_features_box_office_region", "") or ""
+        ).strip()
+        if region and region.lower() != "domestic":
+            url = f"{url}?area={region}"
+        return url
+
     def fetch_weekend_box_office(
         self,
         year: Optional[int] = None,
@@ -166,7 +275,7 @@ class BoxOfficeService:
         if year is None or week is None:
             _, _, year, week = self.get_weekend_dates()
 
-        url = f"{self.BASE_URL}/weekend/{year}W{week:02d}/"
+        url = self._build_weekend_url(year, week)
         logger.info(f"Fetching box office data from: {url}")
 
         try:

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -169,6 +169,13 @@ class Settings(BaseSettings):
         le=30,
         description="Number of movies to fetch from Box Office Mojo (1-30)",
     )
+    boxarr_features_box_office_region: str = Field(
+        default="",
+        description=(
+            "Box Office Mojo region 'area' code (e.g. 'NL', 'DE'). "
+            "Empty means US & Canada domestic (no ?area parameter)."
+        ),
+    )
     boxarr_features_auto_add: bool = Field(
         default=False, description="Automatically add movies to Radarr"
     )

--- a/src/web/static/js/app.js
+++ b/src/web/static/js/app.js
@@ -1286,6 +1286,8 @@ function reloadScheduler() {
         
         // Box office fetch limit
         config.boxarr_features_box_office_limit = parseInt(document.getElementById('boxOfficeLimit')?.value || '10');
+        // Box office region
+        config.boxarr_features_box_office_region = document.getElementById('boxOfficeRegion')?.value || '';
         // Handle new auto-add advanced options
         config.boxarr_features_auto_add_limit = parseInt(document.getElementById('autoAddLimit')?.value || '10');
         config.boxarr_features_auto_add_genre_filter_enabled = document.getElementById('genreFilterEnabled')?.checked || false;

--- a/src/web/templates/setup.html
+++ b/src/web/templates/setup.html
@@ -205,6 +205,17 @@
                     <small class="text-muted">Number of movies to fetch from Box Office Mojo each week (1-30)</small>
                 </div>
 
+                <!-- Box Office Region -->
+                <div class="form-group" style="margin-top: 1rem;">
+                    <label for="boxOfficeRegion" class="form-label">Box Office Region</label>
+                    <select id="boxOfficeRegion" name="boxarr_features_box_office_region" class="form-select">
+                        {% for code, name in box_office_regions %}
+                        <option value="{{ code }}" {% if box_office_region == code %}selected{% endif %}>{{ name }}</option>
+                        {% endfor %}
+                    </select>
+                    <small class="text-muted">Which Box Office Mojo weekend chart to fetch (grosses are shown in the region's local currency)</small>
+                </div>
+
                 <!-- Auto-Add Advanced Options -->
                 <div id="autoAddOptions" class="auto-add-options {% if auto_add %}active{% endif %}" style="margin-left: 2rem; margin-top: 1rem; padding: 1rem; background: var(--bg-color); border-radius: 8px; border-left: 3px solid var(--primary-color);">
                     <!-- Top X Movies Limit -->

--- a/tests/unit/test_box_office_region.py
+++ b/tests/unit/test_box_office_region.py
@@ -1,0 +1,91 @@
+"""Unit tests for the selectable Box Office Mojo region."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import yaml
+
+from src.core.boxoffice import BOX_OFFICE_REGIONS, BoxOfficeService
+
+
+class TestBuildWeekendUrl:
+    """Test that the weekend URL respects the configured region."""
+
+    def setup_method(self):
+        self.service = BoxOfficeService()
+
+    def _build(self, region):
+        with patch(
+            "src.core.boxoffice.settings",
+            SimpleNamespace(boxarr_features_box_office_region=region),
+        ):
+            return self.service._build_weekend_url(2024, 48)
+
+    def test_domestic_empty_has_no_area_param(self):
+        """Empty region keeps the domestic URL byte-for-byte unchanged."""
+        assert self._build("") == "https://www.boxofficemojo.com/weekend/2024W48/"
+
+    def test_domestic_keyword_has_no_area_param(self):
+        """The literal 'domestic' keyword also fetches the default chart."""
+        assert (
+            self._build("domestic") == "https://www.boxofficemojo.com/weekend/2024W48/"
+        )
+
+    def test_region_appends_area_param(self):
+        """A region code appends ?area=CODE to the weekend URL."""
+        assert (
+            self._build("NL")
+            == "https://www.boxofficemojo.com/weekend/2024W48/?area=NL"
+        )
+
+    def test_region_whitespace_is_stripped(self):
+        """Surrounding whitespace on the region code is ignored."""
+        assert (
+            self._build("  DE  ")
+            == "https://www.boxofficemojo.com/weekend/2024W48/?area=DE"
+        )
+
+    def test_missing_region_attribute_defaults_domestic(self):
+        """A settings object without the field falls back to domestic."""
+        with patch("src.core.boxoffice.settings", SimpleNamespace()):
+            assert (
+                self.service._build_weekend_url(2024, 48)
+                == "https://www.boxofficemojo.com/weekend/2024W48/"
+            )
+
+
+class TestRegionCatalog:
+    """Test the region catalog exposed to the settings UI."""
+
+    def test_domestic_is_first_and_empty(self):
+        """The domestic option is first and maps to the empty area code."""
+        assert BOX_OFFICE_REGIONS[0][0] == ""
+
+    def test_known_codes_present(self):
+        """A few well-known area codes are available."""
+        codes = {code for code, _ in BOX_OFFICE_REGIONS}
+        assert {"NL", "DE", "FR", "GB", "JP"} <= codes
+
+
+class TestConfigRoundTrip:
+    """Test configuration defaults and persistence for the region field."""
+
+    def test_default_region_is_domestic(self):
+        """Default region is the empty (domestic) string."""
+        from src.utils.config import Settings
+
+        s = Settings()
+        assert s.boxarr_features_box_office_region == ""
+
+    def test_region_round_trip_via_yaml(self, tmp_path):
+        """A region saved under features loads back onto the setting."""
+        from src.utils.config import Settings
+
+        config_path = tmp_path / "local.yaml"
+        config_path.write_text(
+            yaml.dump({"boxarr": {"features": {"box_office_region": "NL"}}})
+        )
+
+        s = Settings()
+        s.load_from_yaml(config_path)
+        assert s.boxarr_features_box_office_region == "NL"


### PR DESCRIPTION
## Problem

Boxarr always scraped Box Office Mojo's US & Canada domestic weekend chart. Users outside the US/Canada had no way to track box office for their own country/region, so the dashboard only ever reflected the domestic market.

## Root cause

The weekend URL was hardcoded to the domestic endpoint (`/weekend/YYYYWww/`) with no region parameter, and there was no configuration surface to choose a different Box Office Mojo region (`?area=CODE`).

## What this change does

- **Config model** (`src/utils/config.py`): adds `boxarr_features_box_office_region` (default `""` = US & Canada domestic), placed alongside `boxarr_features_box_office_limit` and round-tripped through the existing generic `boxarr.features` YAML handler.
- **Scraper** (`src/core/boxoffice.py`): adds a `BOX_OFFICE_REGIONS` catalog (82 real Box Office Mojo area codes extracted from the live intl page, domestic first) and a `_build_weekend_url(year, week)` helper. The service reads the configured region internally and appends `?area=CODE` only for a non-empty, non-domestic region. The domestic path is byte-for-byte identical to before, so existing behavior is unchanged.
- **Config API** (`src/api/routes/config.py`): accepts and persists `box_office_region` under `boxarr.features`.
- **UI** (`setup.html` + `app.js`): adds a "Box Office Region" drop-down next to the existing Fetch Limit control, populated from the region catalog and defaulting to the currently-selected value.

## Testing

- Full suite (`pytest -m "not slow"`): **136 passed, 1 skipped** (129 baseline + 7 new tests in `tests/unit/test_box_office_region.py` covering URL building, whitespace handling, region-catalog sanity, and config round-trip).
- `black --check --target-version py310` on all touched files: clean.
- `flake8 --select=E9,F63,F7,F82` over `src/`/`tests/`: no findings.
- Verified the intl weekend page (`?area=NL`) returns the same `a-bordered` table and `/release/rlNNN/` links the existing parser targets, so the parser handles intl pages unchanged.

Note: intl grosses are reported in the region's local currency and are displayed without a currency label; changing the region does not retroactively re-fetch past weeks. These are known UX follow-ups outside this feature's scope.

Fixes #109
