### PR TITLE
fix: make Box Office Mojo timeout configurable with retry-backoff

### DIFF
--- a/src/core/boxoffice.py
+++ b/src/core/boxoffice.py
@@ -1,6 +1,7 @@
 """Box Office Mojo scraper for fetching weekly box office data."""
 
 import re
+import time
 from dataclasses import asdict, dataclass
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Tuple
@@ -127,6 +128,8 @@ class BoxOfficeService:
 
     BASE_URL = "https://www.boxofficemojo.com"
     USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+    MAX_FETCH_ATTEMPTS = 3
+    RETRY_BACKOFF_SECONDS = (2, 4)
 
     def __init__(self, http_client: Optional[httpx.Client] = None):
         """
@@ -136,7 +139,9 @@ class BoxOfficeService:
             http_client: Optional HTTP client for testing
         """
         self.client = http_client or httpx.Client(
-            headers={"User-Agent": self.USER_AGENT}, timeout=30.0, follow_redirects=True
+            headers={"User-Agent": self.USER_AGENT},
+            timeout=getattr(settings, "boxoffice_timeout", 120.0),
+            follow_redirects=True,
         )
 
     def __enter__(self):
@@ -278,13 +283,28 @@ class BoxOfficeService:
         url = self._build_weekend_url(year, week)
         logger.info(f"Fetching box office data from: {url}")
 
+        response = None
+        for attempt in range(1, self.MAX_FETCH_ATTEMPTS + 1):
+            try:
+                response = self.client.get(url)
+                break
+            except (httpx.TimeoutException, httpx.TransportError) as e:
+                if attempt >= self.MAX_FETCH_ATTEMPTS:
+                    logger.error(f"Failed to fetch box office data: {e}")
+                    raise BoxOfficeError(
+                        "Failed to fetch box office data after "
+                        f"{self.MAX_FETCH_ATTEMPTS} attempts: {e}. Consider raising "
+                        "the boxoffice_timeout setting if this persists."
+                    ) from e
+                logger.warning(
+                    f"Box office fetch attempt {attempt}/{self.MAX_FETCH_ATTEMPTS} "
+                    f"failed ({e}), retrying"
+                )
+                time.sleep(self.RETRY_BACKOFF_SECONDS[attempt - 1])
+
         try:
-            response = self.client.get(url)
             response.raise_for_status()
         except httpx.HTTPError as e:
-            logger.error(f"Failed to fetch box office data: {e}")
-            raise BoxOfficeError(f"Failed to fetch box office data: {e}") from e
-        except Exception as e:
             logger.error(f"Failed to fetch box office data: {e}")
             raise BoxOfficeError(f"Failed to fetch box office data: {e}") from e
 

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -176,6 +176,12 @@ class Settings(BaseSettings):
             "Empty means US & Canada domestic (no ?area parameter)."
         ),
     )
+    boxoffice_timeout: float = Field(
+        default=120.0,
+        ge=5,
+        le=600,
+        description="HTTP timeout in seconds for Box Office Mojo requests",
+    )
     boxarr_features_auto_add: bool = Field(
         default=False, description="Automatically add movies to Radarr"
     )

--- a/tests/unit/test_boxoffice.py
+++ b/tests/unit/test_boxoffice.py
@@ -7,6 +7,7 @@ import httpx
 import pytest
 
 from src.core.boxoffice import BoxOfficeError, BoxOfficeService
+from src.utils.config import settings
 
 
 class TestGetWeekendDates:
@@ -267,7 +268,8 @@ class TestBoxOfficeHTMLParsing:
         assert movies[1].title == "Top Gun: Maverick"
         assert movies[2].title == "Black Panther: Wakanda Forever"
 
-    def test_network_failure_handling(self):
+    @patch("src.core.boxoffice.time.sleep")
+    def test_network_failure_handling(self, mock_sleep):
         """Test handling when Box Office Mojo is not accessible."""
         with patch.object(self.service.client, "get") as mock_get:
             mock_get.side_effect = httpx.ConnectError("Connection timeout")
@@ -335,3 +337,68 @@ class TestBoxOfficeHTMLParsing:
         assert len(movies) == 2
         assert movies[0].release_url == "/release/rl1234567890/"
         assert movies[1].release_url == "/release/rl9876543210/"
+
+
+class TestBoxOfficeTimeoutAndRetries:
+    """Test configurable timeout and retry-with-backoff on transport failures."""
+
+    # Minimal table whose title href is not a /release/ link, so no enrichment
+    # GETs are triggered during fetch_weekend_box_office.
+    SUCCESS_HTML = """
+    <html><body>
+        <table class="a-bordered">
+            <tr><th>Rank</th><th>LW</th><th>Movie</th><th>Weekend</th></tr>
+            <tr>
+                <td>1</td>
+                <td>-</td>
+                <td><a href="/title/tt1/">Test Movie</a></td>
+                <td>$100,000</td>
+            </tr>
+        </table>
+    </body></html>
+    """
+
+    @patch("src.core.boxoffice.httpx.Client")
+    def test_client_created_with_configured_timeout(self, mock_client_cls):
+        """The HTTP client should use the configured boxoffice_timeout."""
+        BoxOfficeService()
+
+        _, kwargs = mock_client_cls.call_args
+        assert kwargs["timeout"] == settings.boxoffice_timeout
+        assert kwargs["timeout"] == 120.0
+
+    @patch("src.core.boxoffice.time.sleep")
+    def test_transient_timeout_then_success(self, mock_sleep):
+        """A single timeout should be retried and then succeed."""
+        success = Mock()
+        success.text = self.SUCCESS_HTML
+        success.raise_for_status = Mock()
+
+        mock_client = MagicMock()
+        mock_client.get.side_effect = [
+            httpx.TimeoutException("slow"),
+            success,
+        ]
+
+        service = BoxOfficeService(http_client=mock_client)
+        movies = service.fetch_weekend_box_office(2024, 48)
+
+        assert len(movies) == 1
+        assert movies[0].title == "Test Movie"
+        assert mock_client.get.call_count == 2
+        mock_sleep.assert_called_once_with(2)
+
+    @patch("src.core.boxoffice.time.sleep")
+    def test_three_consecutive_timeouts_raise(self, mock_sleep):
+        """Three consecutive timeouts should raise BoxOfficeError."""
+        mock_client = MagicMock()
+        mock_client.get.side_effect = httpx.TimeoutException("slow")
+
+        service = BoxOfficeService(http_client=mock_client)
+
+        with pytest.raises(BoxOfficeError) as exc_info:
+            service.fetch_weekend_box_office(2024, 48)
+
+        assert "boxoffice_timeout" in str(exc_info.value)
+        assert mock_client.get.call_count == 3
+        assert mock_sleep.call_count == 2


### PR DESCRIPTION
## Problem

When Boxarr fetched weekend data from Box Office Mojo, the HTTP request used a hardcoded 30-second timeout with no retries. On slow networks or when Box Office Mojo responded sluggishly, the request would hit the timeout and fail outright, leaving users unable to load box office data with no way to raise the limit.

## Root cause

`BoxOfficeService` created its `httpx.Client` with a fixed `timeout=30.0`, and the weekend-page GET had no retry logic — a single transient timeout or transport hiccup aborted the whole fetch.

## What this change does

- Adds a `boxoffice_timeout` setting (default `120.0`, range `5`–`600`) to the `Settings` model, mirroring the existing `radarr_timeout`.
- Wires that setting into the `httpx.Client` via `getattr(settings, "boxoffice_timeout", 120.0)`, replacing the hardcoded `30.0`.
- Adds retry-with-backoff to the weekend-page fetch: up to 3 attempts on `httpx.TimeoutException` / `httpx.TransportError`, sleeping 2s then 4s between attempts, with a per-retry warning log. On final failure it raises a `BoxOfficeError` whose message points users at the `boxoffice_timeout` setting. HTTP status errors are handled separately and are not retried.

## Testing

- Full suite (`pytest tests/ -q -m "not slow"`): 130 passed, 1 skipped, 0 failures (+3 new tests vs. main baseline, zero regressions).
- New tests cover: client built with the configured timeout, a transient timeout followed by success (one retry), and three consecutive timeouts raising `BoxOfficeError`. The new tests fail without the fix.
- `black --check` clean on all touched files; `flake8 --select=E9,F63,F7,F82` exits 0.

Fixes #110

