### PR TITLE
chore: prepare v1.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.0] - 2026-07-23
+
+### Added
+- **Selectable Box Office Region**: New setup dropdown to pick a Box Office Mojo region, driving an `?area=CODE` query so charts can track box office beyond US & Canada domestic (#109, #112)
+- **Configurable Box Office Timeout**: New `boxoffice_timeout` setting (default 120s, range 5-600) plus a 3-attempt retry with backoff for more resilient Box Office Mojo requests (#110, #113)
+- **UI Polish**: Async refresh button with a progress endpoint, a week tenure badge, and a recent-weeks grid on the overview page (#105)
+
+### Fixed
+- **Ignore Button**: Fixed single-quote escaping in the overview ignore-button `onclick` handler so movies with apostrophes in their titles can be ignored (#106, #111)
+- **Event-Loop Blocking**: Manual box office routes now offload the blocking Box Office Mojo scraper to a worker thread, so a wedged upstream (compounded by request retries) no longer stalls the asyncio event loop and hangs every request, including `/api/health`
+- **Timeout Preservation on Save**: Saving configuration from the settings UI now preserves the `boxoffice_timeout` (and Radarr request timeout) value instead of silently reverting it to the default
+
+### Changed
+- **Health-Check Logging**: Suppressed `uvicorn.access` log lines for `/api/health` to keep logs readable under frequent health probes (#107)
+
 ## [1.7.0] - 2026-04-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -129,6 +129,16 @@ environment:
 
 **[View reverse proxy setup guide →](https://github.com/iongpt/boxarr/wiki/Configuration-Guide#reverse-proxy-configuration)**
 
+### Box Office Region & Timeout
+
+By default Boxarr tracks the US & Canada domestic chart. Set a Box Office Mojo `area` code to follow a different region, and tune the scraper timeout for slow connections.
+
+```yaml
+environment:
+  - BOXARR_FEATURES_BOX_OFFICE_REGION=NL  # BOM area code (e.g. NL, DE, GB); empty = US & Canada domestic
+  - BOXOFFICE_TIMEOUT=120                 # Box Office Mojo request timeout in seconds (default 120, range 5-600)
+```
+
 ### API Access
 
 Boxarr provides a REST API for integration and automation.

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -27,6 +27,9 @@ boxarr:
     auto_add: true
     quality_upgrade: true
     notifications: false
+    # Box Office Mojo region 'area' code (e.g. "NL", "DE", "GB").
+    # Empty means US & Canada domestic (no ?area parameter).
+    box_office_region: ""
   
   # UI configuration
   ui:
@@ -41,6 +44,9 @@ boxarr:
   data:
     directory: "/config"
     history_retention_days: 90
+
+# Box Office Mojo HTTP request timeout in seconds (default 120, range 5-600)
+boxoffice_timeout: 120
 
 # Logging
 log_level: "INFO"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "boxarr"
-version = "1.7.0"
+version = "1.8.0"
 description = "Box Office Tracking for Radarr"
 readme = "README.md"
 license = {text = "GPL-3.0"}

--- a/src/api/routes/boxoffice.py
+++ b/src/api/routes/boxoffice.py
@@ -1,5 +1,6 @@
 """Box office data routes."""
 
+import asyncio
 from datetime import datetime
 from typing import List, Optional
 
@@ -37,7 +38,7 @@ async def get_current_box_office():
     try:
         # Get current week's box office
         boxoffice_service = BoxOfficeService()
-        movies = boxoffice_service.get_current_week_movies()
+        movies = await asyncio.to_thread(boxoffice_service.get_current_week_movies)
 
         # Match with Radarr if configured
         results = []
@@ -114,7 +115,9 @@ async def get_historical_box_office(year: int, week: int):
 
         # Get historical data
         boxoffice_service = BoxOfficeService()
-        movies = boxoffice_service.fetch_weekend_box_office(year, week)
+        movies = await asyncio.to_thread(
+            boxoffice_service.fetch_weekend_box_office, year, week
+        )
 
         # Return simplified data
         return [

--- a/src/api/routes/config.py
+++ b/src/api/routes/config.py
@@ -55,6 +55,9 @@ class SaveConfigRequest(BaseModel):
     boxarr_features_box_office_limit: int = 10
     # Box office region (BOM area code; "" means US & Canada domestic)
     boxarr_features_box_office_region: str = ""
+    # HTTP request timeouts (seconds); None carries over the current value on save
+    boxoffice_timeout: Optional[float] = Field(default=None, ge=5, le=600)
+    radarr_timeout: Optional[float] = Field(default=None, ge=5, le=600)
     # New auto-add advanced options
     boxarr_features_auto_add_limit: int = 10
     boxarr_features_auto_add_genre_filter_enabled: bool = False
@@ -207,6 +210,14 @@ async def save_configuration(config: SaveConfigRequest):
                 config.radarr_quality_profile_upgrade
             )
 
+        # Preserve request timeout: use posted value, else carry over current
+        # effective value so an omitting save doesn't wipe it back to the default.
+        radarr_config["timeout"] = (
+            config.radarr_timeout
+            if config.radarr_timeout is not None
+            else getattr(settings, "radarr_timeout", 120.0)
+        )
+
         # Add root folder config if provided
         # Semantics (order-first):
         # - If field present: respect posted 'enabled'. For mappings:
@@ -301,6 +312,13 @@ async def save_configuration(config: SaveConfigRequest):
                     "theme": config.boxarr_ui_theme,
                 },
             },
+            # Box office scraper timeout: preserve posted value, else carry over
+            # the current effective value so a save omitting it keeps the setting.
+            "boxoffice_timeout": (
+                config.boxoffice_timeout
+                if config.boxoffice_timeout is not None
+                else getattr(settings, "boxoffice_timeout", 120.0)
+            ),
         }
 
         # Save to local.yaml

--- a/src/api/routes/movies.py
+++ b/src/api/routes/movies.py
@@ -465,7 +465,7 @@ async def add_movie_to_radarr(request: AddMovieRequest):
 
         if already:
             # Regenerate affected weeks so UI reflects correct status immediately
-            regenerate_weeks_with_movie(req_title)
+            await asyncio.to_thread(regenerate_weeks_with_movie, req_title)
 
             return {
                 "success": True,
@@ -484,7 +484,7 @@ async def add_movie_to_radarr(request: AddMovieRequest):
 
         if result:
             # Find and regenerate weeks containing this movie
-            regenerate_weeks_with_movie(req_title)
+            await asyncio.to_thread(regenerate_weeks_with_movie, req_title)
 
             return {
                 "success": True,

--- a/src/api/routes/scheduler.py
+++ b/src/api/routes/scheduler.py
@@ -1,5 +1,6 @@
 """Scheduler management routes."""
 
+import asyncio
 import json
 from datetime import datetime
 from pathlib import Path
@@ -280,8 +281,8 @@ async def update_specific_week(request: UpdateWeekRequest):  # noqa: C901
         # Get box office data
         boxoffice_service = BoxOfficeService()
         limit = settings.boxarr_features_box_office_limit
-        box_office_movies = boxoffice_service.fetch_weekend_box_office(
-            year, week, limit=limit
+        box_office_movies = await asyncio.to_thread(
+            boxoffice_service.fetch_weekend_box_office, year, week, limit=limit
         )
 
         if not box_office_movies:

--- a/src/version.py
+++ b/src/version.py
@@ -49,7 +49,7 @@ def get_version() -> str:
                         version = f"{base_version}-dev"
                 else:
                     # Just a commit hash, use fallback
-                    version = "1.7.0-dev"
+                    version = "1.8.0-dev"
 
             return version
 
@@ -59,7 +59,7 @@ def get_version() -> str:
 
     # Fallback version for when git is not available (e.g., in Docker)
     # This should be updated when creating a new release
-    return "1.7.0"
+    return "1.8.0"
 
 
 # Cache the version at import time

--- a/tests/integration/test_config_timeout_preserve.py
+++ b/tests/integration/test_config_timeout_preserve.py
@@ -1,0 +1,105 @@
+"""Integration tests: settings-UI saves preserve the box office timeout.
+
+An earlier bug rebuilt ``local.yaml`` from scratch on every save without the
+``boxoffice_timeout`` field, so a user-set timeout silently reverted to the
+default. These tests assert both a posted value and an omitted-but-existing
+value survive a Save round-trip.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+from fastapi.testclient import TestClient
+
+import src.api.routes.config as cfg_routes
+import src.utils.config as cfg_utils
+from src.api.app import create_app
+
+
+class _FakeRadarrService:
+    def __init__(self, *_, **__):
+        pass
+
+    def test_connection(self) -> bool:
+        return True
+
+
+def _base_payload() -> dict:
+    return {
+        "radarr_url": "http://localhost:7878",
+        "radarr_api_key": "test-key",
+        "radarr_root_folder": "/movies",
+        "radarr_quality_profile_default": "HD-1080p",
+        "radarr_quality_profile_upgrade": "",
+        "boxarr_scheduler_enabled": False,
+        "boxarr_scheduler_cron": "0 23 * * 2",
+        "boxarr_features_auto_add": False,
+        "boxarr_features_quality_upgrade": True,
+        "boxarr_ui_theme": "light",
+    }
+
+
+def _read_config(dir_path: Path) -> dict:
+    with open(dir_path / "local.yaml") as f:
+        return yaml.safe_load(f) or {}
+
+
+def _setup(tmp_path, monkeypatch):
+    monkeypatch.setenv("BOXARR_DATA_DIRECTORY", str(tmp_path))
+    monkeypatch.setattr(cfg_routes, "RadarrService", _FakeRadarrService)
+    # Force settings to reload from the seeded tmp directory.
+    cfg_utils._settings = None
+    return TestClient(create_app())
+
+
+def test_posted_timeout_is_persisted(tmp_path, monkeypatch):
+    """A save that posts boxoffice_timeout writes it top-level in the config."""
+    client = _setup(tmp_path, monkeypatch)
+
+    payload = _base_payload()
+    payload["boxoffice_timeout"] = 300
+
+    resp = client.post("/api/config/save", json=payload)
+    assert resp.status_code == 200
+    assert resp.json().get("success") is True
+
+    current = _read_config(tmp_path)
+    assert current.get("boxoffice_timeout") == 300
+
+
+def test_omitted_timeout_is_carried_over(tmp_path, monkeypatch):
+    """A save omitting boxoffice_timeout preserves the current non-default value."""
+    # Seed an existing non-default timeout so the carry-over has something to keep.
+    (tmp_path / "local.yaml").write_text(yaml.dump({"boxoffice_timeout": 240}))
+
+    client = _setup(tmp_path, monkeypatch)
+
+    payload = _base_payload()  # No boxoffice_timeout key.
+    resp = client.post("/api/config/save", json=payload)
+    assert resp.status_code == 200
+    assert resp.json().get("success") is True
+
+    current = _read_config(tmp_path)
+    assert current.get("boxoffice_timeout") == 240
+
+
+def test_omitted_radarr_timeout_is_carried_over(tmp_path, monkeypatch):
+    """The same carry-over protects the Radarr request timeout."""
+    (tmp_path / "local.yaml").write_text(
+        yaml.dump(
+            {
+                "radarr": {"timeout": 200, "api_key": "test-key"},
+            }
+        )
+    )
+
+    client = _setup(tmp_path, monkeypatch)
+
+    payload = _base_payload()  # No radarr_timeout key.
+    resp = client.post("/api/config/save", json=payload)
+    assert resp.status_code == 200
+    assert resp.json().get("success") is True
+
+    current = _read_config(tmp_path)
+    assert current.get("radarr", {}).get("timeout") == 200

--- a/tests/unit/test_boxoffice_route_threaded.py
+++ b/tests/unit/test_boxoffice_route_threaded.py
@@ -1,0 +1,88 @@
+"""Unit tests for the manual box office routes offloading to a worker thread.
+
+The blocking Box Office Mojo scraper is called from async handlers via
+``asyncio.to_thread``. These tests patch the service and assert the endpoints
+still return the scraped data (and propagate errors) through the threaded path.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.api.app import create_app
+from src.core.boxoffice import BoxOfficeError, BoxOfficeMovie
+
+
+@pytest.fixture
+def client():
+    return TestClient(create_app())
+
+
+class _FakeService:
+    """Stands in for BoxOfficeService with synchronous, blocking-style calls."""
+
+    def __init__(self, *_, **__):
+        pass
+
+    def get_current_week_movies(self, limit: int = 10):
+        return [
+            BoxOfficeMovie(
+                rank=1,
+                title="Threaded Movie",
+                weekend_gross=1000.0,
+                total_gross=5000.0,
+                weeks_released=1,
+            )
+        ]
+
+    def fetch_weekend_box_office(self, year, week, limit: int = 10):
+        return [
+            BoxOfficeMovie(
+                rank=1,
+                title="Historical Movie",
+                weekend_gross=2000.0,
+                total_gross=8000.0,
+                weeks_released=2,
+            )
+        ]
+
+
+def test_current_returns_data_via_thread(client):
+    """/api/boxoffice/current returns scraped data through the threaded path."""
+    with (
+        patch("src.api.routes.boxoffice.BoxOfficeService", _FakeService),
+        patch("src.api.routes.boxoffice.settings") as mock_settings,
+    ):
+        mock_settings.radarr_api_key = ""
+        resp = client.get("/api/boxoffice/current")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body[0]["title"] == "Threaded Movie"
+    assert body[0]["weekend_gross"] == 1000.0
+
+
+def test_history_returns_data_via_thread(client):
+    """/api/boxoffice/history returns scraped data through the threaded path."""
+    with patch("src.api.routes.boxoffice.BoxOfficeService", _FakeService):
+        resp = client.get("/api/boxoffice/history/2024/W48")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body[0]["title"] == "Historical Movie"
+    assert body[0]["total_gross"] == 8000.0
+
+
+def test_history_propagates_scraper_error(client):
+    """A BoxOfficeError from the threaded scraper still surfaces as HTTP 500."""
+
+    class _FailingService(_FakeService):
+        def fetch_weekend_box_office(self, year, week, limit: int = 10):
+            raise BoxOfficeError("Box Office Mojo unavailable")
+
+    with patch("src.api.routes.boxoffice.BoxOfficeService", _FailingService):
+        resp = client.get("/api/boxoffice/history/2024/W48")
+
+    assert resp.status_code == 500
+    assert "Box Office Mojo unavailable" in resp.json()["detail"]


### PR DESCRIPTION
## Summary

Prepares the Boxarr v1.8.0 release. Five punch-list items:

1. **Offload blocking box office scraper to a worker thread** — the synchronous scraper was being called directly from `async` request handlers, blocking the event loop. Now wrapped in `asyncio.to_thread` at every call site. (Addresses a finding from the pre-release audit.)
2. **Preserve request timeouts across settings-UI saves** — saving the settings page previously wiped `boxoffice_timeout` and `radarr_timeout`. They are now carried over (or taken from the posted value). (Addresses a finding from the pre-release audit.)
3. **Version bump** to 1.8.0.
4. **CHANGELOG** — new `[1.8.0]` section.
5. **Docs** — document the box office region and timeout settings.

## Changes

**Task 1 — event-loop offloading** (`src/api/routes/boxoffice.py`, `src/api/routes/scheduler.py`, `src/api/routes/movies.py`): wrapped the blocking scraper in `await asyncio.to_thread(...)` at all four async call sites (`get_current_week_movies`, `fetch_weekend_box_office` in boxoffice and scheduler, and `regenerate_weeks_with_movie` in the movies add-to-Radarr handler). Return values and exception semantics (`BoxOfficeError` -> HTTP 500) preserved. The `src/core/scheduler.py` executor path was intentionally left untouched. Added `tests/unit/test_boxoffice_route_threaded.py`.

**Task 2 — preserve timeouts** (`src/api/routes/config.py`): added optional `boxoffice_timeout` and `radarr_timeout` fields to `SaveConfigRequest` (`Optional[float]`, `ge=5 le=600`). On save, `boxoffice_timeout` is written as a top-level key and `radarr_timeout` to `radarr.timeout` — exactly where the loader reads them — using the posted value when present, else the existing setting. Added `tests/integration/test_config_timeout_preserve.py`.

**Task 3 — version bump** (`pyproject.toml`, `src/version.py`): 1.7.0 -> 1.8.0.

**Task 4 — CHANGELOG** (`CHANGELOG.md`): added `## [1.8.0] - 2026-07-23` following the Keep-a-Changelog convention, covering #111, #112, #113, #107, #105 and this PR's two fixes.

**Task 5 — docs** (`config/default.yaml`, `README.md`): documented `box_office_region` (under `boxarr.features`) and `boxoffice_timeout` (top-level), plus a README "Box Office Region & Timeout" subsection with the derived env vars `BOXARR_FEATURES_BOX_OFFICE_REGION` and `BOXOFFICE_TIMEOUT`. Values equal model defaults, so effective behavior is unchanged.

## Testing

All CI gates pass in the release-prep worktree:

- `pytest tests/ -q` -> 147 passed, 1 skipped (141 baseline + 6 new)
- `black --check src/ tests/` -> pass
- `isort --check-only src/ tests/` -> pass
- `flake8 --select=E9,F63,F7,F82 src/` -> pass
- `mypy src/ --ignore-missing-imports --no-strict-optional` -> Success, no issues in 27 source files
