### PR TITLE
fix: match auto-add search result by IMDb id to avoid adding the wrong movie

### DIFF
--- a/src/core/auto_add.py
+++ b/src/core/auto_add.py
@@ -1,15 +1,46 @@
 """Shared auto-add logic for adding unmatched movies to Radarr."""
 
-from typing import List
+from typing import Any, Dict, List, Optional
 
 from ..utils.config import settings
 from ..utils.logger import get_logger
+from .boxoffice import BoxOfficeMovie
 from .ignore_list import IgnoreList
 from .matcher import MatchResult
 from .radarr import RadarrService
 from .root_folder_manager import RootFolderManager
 
 logger = get_logger(__name__)
+
+
+def _normalize_imdb_id(imdb_id: Optional[str]) -> Optional[str]:
+    """Normalize an IMDb id for comparison (case/whitespace insensitive)."""
+    if not imdb_id:
+        return None
+    return imdb_id.strip().lower()
+
+
+def _select_search_result(
+    search_results: List[Dict[str, Any]], box_office_movie: BoxOfficeMovie
+) -> Dict[str, Any]:
+    """
+    Select the search result matching the box-office movie's IMDb id.
+
+    When the box-office movie carries an IMDb id, prefer the result whose
+    ``imdbId`` matches it. If none matches - or no IMDb id is available -
+    fall back to the first result to preserve the previous behavior.
+    """
+    target = _normalize_imdb_id(box_office_movie.imdb_id)
+    if target:
+        for candidate in search_results:
+            if _normalize_imdb_id(candidate.get("imdbId")) == target:
+                return candidate
+        logger.warning(
+            f"No TMDB search result for '{box_office_movie.title}' matched "
+            f"IMDb id {box_office_movie.imdb_id}; falling back to top result "
+            f"'{search_results[0].get('title')}'"
+        )
+    return search_results[0]
 
 
 def auto_add_missing_movies(
@@ -74,7 +105,7 @@ def auto_add_missing_movies(
                 )
                 continue
 
-            movie_info = search_results[0]
+            movie_info = _select_search_result(search_results, result.box_office_movie)
 
             # Skip movies on the ignore list
             movie_tmdb_id = movie_info.get("tmdbId")

--- a/tests/unit/test_auto_add_imdb_match.py
+++ b/tests/unit/test_auto_add_imdb_match.py
@@ -1,0 +1,44 @@
+"""Unit tests for IMDb-aware search result selection in auto-add."""
+
+from src.core.auto_add import _select_search_result
+from src.core.boxoffice import BoxOfficeMovie
+
+
+def _results():
+    """Three Radarr search results with distinct IMDb ids."""
+    return [
+        {"tmdbId": 10, "title": "Ambiguous Title (2001)", "imdbId": "tt0000001"},
+        {"tmdbId": 20, "title": "Ambiguous Title (2015)", "imdbId": "tt0000002"},
+        {"tmdbId": 30, "title": "Ambiguous Title (2024)", "imdbId": "tt0000003"},
+    ]
+
+
+def test_imdb_match_prefers_matching_result_over_first():
+    """When the box-office movie carries an IMDb id, the matching result wins."""
+    movie = BoxOfficeMovie(rank=1, title="Ambiguous Title", imdb_id="tt0000003")
+    selected = _select_search_result(_results(), movie)
+    assert selected["tmdbId"] == 30
+
+
+def test_imdb_match_is_case_insensitive():
+    """IMDb id comparison normalizes case and surrounding whitespace."""
+    movie = BoxOfficeMovie(rank=1, title="Ambiguous Title", imdb_id="  TT0000002 ")
+    selected = _select_search_result(_results(), movie)
+    assert selected["tmdbId"] == 20
+
+
+def test_no_imdb_id_falls_back_to_first_result():
+    """Without an IMDb id, behavior is identical to taking the first result."""
+    movie = BoxOfficeMovie(rank=1, title="Ambiguous Title", imdb_id=None)
+    selected = _select_search_result(_results(), movie)
+    assert selected["tmdbId"] == 10
+
+
+def test_no_match_falls_back_to_first_and_warns(caplog):
+    """An unmatched IMDb id falls back to result[0] and logs a warning."""
+    movie = BoxOfficeMovie(rank=1, title="Ambiguous Title", imdb_id="tt9999999")
+    with caplog.at_level("WARNING"):
+        selected = _select_search_result(_results(), movie)
+    assert selected["tmdbId"] == 10
+    assert any("tt9999999" in rec.message for rec in caplog.records)
+    assert any("Ambiguous Title" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Problem

When Boxarr auto-adds a missing box-office movie to Radarr, it could add the *wrong* film. For ambiguous, generic, or non-English titles, Radarr's lookup often returns several candidates, and Boxarr was blindly taking the first one. That meant a remake, a same-named unrelated film, or a foreign-title collision could be added instead of the movie actually in the box office.

## Root cause

`auto_add_missing_movies` in `src/core/auto_add.py` used `movie_info = search_results[0]` — always the top Radarr lookup hit — even when the box-office movie already carried a known `imdb_id` that uniquely identifies the correct film.

## Change

- Added two module-level helpers in `src/core/auto_add.py`:
  - `_normalize_imdb_id` — lowercases and strips an IMDb id for robust comparison.
  - `_select_search_result(search_results, box_office_movie)` — when the box-office movie has an `imdb_id`, returns the Radarr lookup result whose `imdbId` matches (normalized for case/whitespace). If nothing matches, it logs a warning naming both the box-office title and the fallback top-result title, then returns `search_results[0]`. When there is no `imdb_id`, it returns `search_results[0]` immediately, so behavior is identical to before.
- The single call site now uses this helper instead of indexing `[0]` directly.

Field shapes verified against source: Radarr `/api/v3/movie/lookup` results expose `imdbId` as `tt...`, and `BoxOfficeMovie.imdb_id` is populated as `tt...` by `enrich_with_imdb_ids` — the same format on both sides, so equality after normalization is sound.

## Testing

- `pytest tests/ -q`: 145 passed, 1 skipped (baseline 141 passed + 1 skipped; +4 new tests, all green).
- New `tests/unit/test_auto_add_imdb_match.py` covers: IMDb match selects the correct result over the top hit; case/whitespace-insensitive matching; no `imdb_id` falls back to the top result; no-match falls back to the top result and emits a warning naming the IMDb id and title.
- `black --check --target-version py310`, `isort --check-only`, `flake8 --select=E9,F63,F7,F82 src/`, and `mypy src/ --ignore-missing-imports --no-strict-optional` all clean.
