### PR TITLE
fix: correct year-boundary week nav and URL-encode overview search params

### DIFF
--- a/src/api/routes/web.py
+++ b/src/api/routes/web.py
@@ -1,9 +1,9 @@
 """Web UI routes."""
 
 import json
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
@@ -554,6 +554,36 @@ async def setup_page(request: Request):
     )
 
 
+def _last_iso_week(year: int) -> int:
+    """Return the last ISO week number of a year (52 or 53).
+
+    Dec 28 is always in the last ISO week of its own year, whereas Dec 31 can
+    fall in week 1 of the following year (e.g. 2018-12-31), which would wrongly
+    report the last week as 1.
+    """
+    return date(year, 12, 28).isocalendar()[1]
+
+
+def _previous_week(year: int, week: int) -> Tuple[int, int]:
+    """Compute the (year, week) immediately preceding the given ISO week."""
+    prev_week_num = week - 1
+    prev_year = year
+    if prev_week_num < 1:
+        prev_year = year - 1
+        prev_week_num = _last_iso_week(prev_year)
+    return prev_year, prev_week_num
+
+
+def _next_week(year: int, week: int) -> Tuple[int, int]:
+    """Compute the (year, week) immediately following the given ISO week."""
+    next_week_num = week + 1
+    next_year = year
+    if next_week_num > _last_iso_week(year):
+        next_year = year + 1
+        next_week_num = 1
+    return next_year, next_week_num
+
+
 @router.get("/{year}W{week}", response_class=HTMLResponse)
 async def serve_weekly_page(request: Request, year: int, week: int):
     """Serve a specific week's page using template with dynamic data."""
@@ -594,13 +624,7 @@ async def serve_weekly_page(request: Request, year: int, week: int):
     next_week = None
 
     # Check for previous week
-    prev_week_num = week - 1
-    prev_year = year
-    if prev_week_num < 1:
-        prev_year = year - 1
-        # Get last week of previous year
-        last_day = date(prev_year, 12, 31)
-        prev_week_num = last_day.isocalendar()[1]
+    prev_year, prev_week_num = _previous_week(year, week)
 
     prev_json = (
         Path(settings.boxarr_data_directory)
@@ -611,13 +635,7 @@ async def serve_weekly_page(request: Request, year: int, week: int):
         prev_week = {"year": prev_year, "week": prev_week_num}
 
     # Check for next week
-    next_week_num = week + 1
-    next_year = year
-    # Check if next week is in next year
-    last_week_of_year = date(year, 12, 31).isocalendar()[1]
-    if next_week_num > last_week_of_year:
-        next_year = year + 1
-        next_week_num = 1
+    next_year, next_week_num = _next_week(year, week)
 
     next_json = (
         Path(settings.boxarr_data_directory)

--- a/src/web/templates/overview.html
+++ b/src/web/templates/overview.html
@@ -808,15 +808,15 @@ select.filter-input {
         <div class="filter-group">
             <label class="filter-label">Status</label>
             <div class="filter-buttons">
-                <a href="?status=all&year={{ year_filter or '' }}&search={{ search_query }}&per_page={{ per_page }}" 
+                <a href="?status=all&year={{ (year_filter or '')|urlencode }}&search={{ search_query|urlencode }}&per_page={{ per_page }}" 
                    class="filter-btn {% if status_filter == 'all' %}active{% endif %}">All</a>
-                <a href="?status=downloaded&year={{ year_filter or '' }}&search={{ search_query }}&per_page={{ per_page }}" 
+                <a href="?status=downloaded&year={{ (year_filter or '')|urlencode }}&search={{ search_query|urlencode }}&per_page={{ per_page }}" 
                    class="filter-btn {% if status_filter == 'downloaded' %}active{% endif %}">Downloaded</a>
-                <a href="?status=missing&year={{ year_filter or '' }}&search={{ search_query }}&per_page={{ per_page }}" 
+                <a href="?status=missing&year={{ (year_filter or '')|urlencode }}&search={{ search_query|urlencode }}&per_page={{ per_page }}" 
                    class="filter-btn {% if status_filter == 'missing' %}active{% endif %}">Missing</a>
-                <a href="?status=not_in_radarr&year={{ year_filter or '' }}&search={{ search_query }}&per_page={{ per_page }}"
+                <a href="?status=not_in_radarr&year={{ (year_filter or '')|urlencode }}&search={{ search_query|urlencode }}&per_page={{ per_page }}"
                    class="filter-btn {% if status_filter == 'not_in_radarr' %}active{% endif %}">Not in Radarr</a>
-                <a href="?status=ignored&year={{ year_filter or '' }}&search={{ search_query }}&per_page={{ per_page }}"
+                <a href="?status=ignored&year={{ (year_filter or '')|urlencode }}&search={{ search_query|urlencode }}&per_page={{ per_page }}"
                    class="filter-btn {% if status_filter == 'ignored' %}active{% endif %}">Ignored</a>
             </div>
         </div>
@@ -1005,13 +1005,13 @@ select.filter-input {
         </div>
         <div class="pagination-controls">
             {% if current_page > 1 %}
-            <a href="?page={{ current_page - 1 }}&status={{ status_filter }}&year={{ year_filter or '' }}&search={{ search_query }}&per_page={{ per_page }}" 
+            <a href="?page={{ current_page - 1 }}&status={{ status_filter }}&year={{ (year_filter or '')|urlencode }}&search={{ search_query|urlencode }}&per_page={{ per_page }}" 
                class="page-btn">← Previous</a>
             {% endif %}
             
             {% for page_num in range(1, total_pages + 1) %}
                 {% if page_num == 1 or page_num == total_pages or (page_num >= current_page - 2 and page_num <= current_page + 2) %}
-                    <a href="?page={{ page_num }}&status={{ status_filter }}&year={{ year_filter or '' }}&search={{ search_query }}&per_page={{ per_page }}" 
+                    <a href="?page={{ page_num }}&status={{ status_filter }}&year={{ (year_filter or '')|urlencode }}&search={{ search_query|urlencode }}&per_page={{ per_page }}" 
                        class="page-btn {% if page_num == current_page %}active{% endif %}">{{ page_num }}</a>
                 {% elif page_num == current_page - 3 or page_num == current_page + 3 %}
                     <span>...</span>
@@ -1019,7 +1019,7 @@ select.filter-input {
             {% endfor %}
             
             {% if current_page < total_pages %}
-            <a href="?page={{ current_page + 1 }}&status={{ status_filter }}&year={{ year_filter or '' }}&search={{ search_query }}&per_page={{ per_page }}" 
+            <a href="?page={{ current_page + 1 }}&status={{ status_filter }}&year={{ (year_filter or '')|urlencode }}&search={{ search_query|urlencode }}&per_page={{ per_page }}" 
                class="page-btn">Next →</a>
             {% endif %}
         </div>

--- a/tests/unit/test_template_urlencode.py
+++ b/tests/unit/test_template_urlencode.py
@@ -1,0 +1,38 @@
+"""Unit tests for URL-encoding of user-text query params in template anchors.
+
+Regression test: overview.html nav anchors interpolate ``search_query`` and
+``year_filter`` into query strings. With only HTML autoescaping (no URL
+encoding), a title like ``Fast & Furious`` produces ``&search=Fast &amp;
+Furious`` which the browser decodes into a broken query, silently dropping the
+search term on any filter/pagination click. Every such anchor must apply
+``|urlencode``; the form inputs (which the browser encodes on submit) are left
+alone.
+"""
+
+import re
+from pathlib import Path
+
+TEMPLATE_DIR = Path(__file__).resolve().parents[2] / "src" / "web" / "templates"
+
+# Matches an anchor query param that emits raw search_query without urlencode.
+RAW_SEARCH = re.compile(r"search=\{\{\s*search_query\s*\}\}")
+# Matches search_query interpolation that pipes through urlencode.
+ENCODED_SEARCH = re.compile(r"search=\{\{\s*search_query\|urlencode\s*\}\}")
+
+
+def test_no_raw_search_query_in_anchors():
+    """No anchor href may interpolate search_query without |urlencode."""
+    content = (TEMPLATE_DIR / "overview.html").read_text(encoding="utf-8")
+    offenders = RAW_SEARCH.findall(content)
+    assert not offenders, (
+        "overview.html interpolates search_query into a query string without "
+        f"|urlencode (drops the search term): {offenders}"
+    )
+
+
+def test_search_query_anchors_use_urlencode():
+    """Every search=... query param must pipe search_query through urlencode."""
+    content = (TEMPLATE_DIR / "overview.html").read_text(encoding="utf-8")
+    assert ENCODED_SEARCH.search(
+        content
+    ), "expected at least one anchor applying |urlencode to search_query"

--- a/tests/unit/test_week_navigation.py
+++ b/tests/unit/test_week_navigation.py
@@ -1,0 +1,60 @@
+"""Unit tests for weekly-page prev/next ISO-week navigation.
+
+Regression tests for the year-boundary bug where the previous year's last
+ISO week was computed from ``date(prev_year, 12, 31)``. When Dec 31 falls in
+ISO week 1 of the following year (e.g. 2018-12-31), that returns 1, so the
+Previous button on a W01 page linked to ``prev_year`` W01 instead of W52/W53.
+"""
+
+import pytest
+
+from src.api.routes.web import _last_iso_week, _next_week, _previous_week
+
+
+class TestLastIsoWeek:
+    """Test last-ISO-week computation across 52- and 53-week years."""
+
+    @pytest.mark.parametrize(
+        "year,expected",
+        [
+            (2018, 52),  # 2018-12-31 falls in ISO week 1 of 2019
+            (2013, 52),  # 2013-12-31 falls in ISO week 1 of 2014
+            (2020, 53),  # 53-week year
+            (2019, 52),  # normal 52-week year
+        ],
+    )
+    def test_last_iso_week(self, year, expected):
+        assert _last_iso_week(year) == expected
+
+
+class TestPreviousWeek:
+    """Test previous-week computation, including year boundaries."""
+
+    @pytest.mark.parametrize(
+        "year,week,expected",
+        [
+            (2019, 1, (2018, 52)),  # Dec 31 in next year's week 1 -> W52
+            (2014, 1, (2013, 52)),  # same edge case
+            (2021, 1, (2020, 53)),  # previous year is a 53-week year
+            (2020, 25, (2020, 24)),  # normal mid-year case
+        ],
+    )
+    def test_previous_week(self, year, week, expected):
+        assert _previous_week(year, week) == expected
+
+
+class TestNextWeek:
+    """Test next-week computation, including year boundaries."""
+
+    @pytest.mark.parametrize(
+        "year,week,expected",
+        [
+            (2018, 51, (2018, 52)),  # W52 exists; must not skip to next year
+            (2018, 52, (2019, 1)),  # last week -> next year's W01
+            (2020, 52, (2020, 53)),  # 53-week year; W53 still exists
+            (2020, 53, (2021, 1)),  # last week of 53-week year -> next year W01
+            (2020, 25, (2020, 26)),  # normal mid-year case
+        ],
+    )
+    def test_next_week(self, year, week, expected):
+        assert _next_week(year, week) == expected


### PR DESCRIPTION
## Problem

Two edge cases in the weekly overview UI:

1. **Week navigation broke across year boundaries.** On a page showing ISO week 01 of a year, the "Previous week" button could jump to week 01 of the prior year instead of its final week (W52/W53). The reverse defect existed too: near the end of certain years the "Next week" button could skip the real final week and land on next year's W01.
2. **Search term silently dropped when filtering.** Typing a query containing special characters (e.g. `Fast & Furious`) and then clicking a status filter or pagination link discarded the search term, so the results reset unexpectedly.

## Root cause

1. The prev/next-week logic computed the last ISO week of a year as `date(Y, 12, 31).isocalendar()[1]`. When Dec 31 falls in ISO week 1 of the *following* year (2018, 2013, ...), this returns `1` instead of `52`/`53`, corrupting both the previous-week target on a W01 page and the next-week boundary check.
2. The filter/pagination anchor `href`s interpolated `search_query` and `year_filter` with HTML autoescaping only. HTML-escaping does not URL-encode `&`, `+`, `=`, etc., so a query with those characters produced a malformed query string that dropped the parameter on navigation.

## Change

- `src/api/routes/web.py`: extracted three module-level helpers — `_last_iso_week` (uses Dec 28, which is always in the year's final ISO week, correctly yielding 52 or 53), `_previous_week`, and `_next_week` — and replaced both inline navigation blocks in `serve_weekly_page` with calls to them.
- `src/web/templates/overview.html`: applied `|urlencode` to `search_query` and `year_filter` in all 8 filter/pagination anchor hrefs. Form inputs and display text left untouched (the browser encodes form submissions; display text must not be URL-encoded).

## Testing

- `tests/unit/test_week_navigation.py`: year-boundary cases (2019W01→2018W52, 2014W01→2013W52, 2021W01→2020W53), a normal mid-year case, and `_last_iso_week`/`_next_week` edge cases including the W51→W52 no-skip case and 53-week years.
- `tests/unit/test_template_urlencode.py`: asserts no nav anchor emits a raw `search_query` and that `|urlencode` is applied.
- Full suite: 156 passed, 1 skipped (baseline 141 + 15 new, 0 failures). Gates clean: `black --check`, `isort --check-only`, `flake8 --select=E9,F63,F7,F82 src/`, `mypy src/ --ignore-missing-imports --no-strict-optional`.

