### PR TITLE
fix: harden XSS sinks in widget, dashboard toasts, and setup JS

### DIFF
--- a/src/api/routes/web.py
+++ b/src/api/routes/web.py
@@ -1,5 +1,6 @@
 """Web UI routes."""
 
+import html
 import json
 from datetime import datetime
 from pathlib import Path
@@ -706,18 +707,23 @@ async def get_widget(request: Request):
         # Build the base URL with correct scheme, host, and base path
         # request.base_url already includes the root_path from FastAPI
         full_url = str(request.base_url).rstrip("/") + "/"
+        full_url_attr = html.escape(full_url, quote=True)
 
-        # Simple widget HTML
-        html = f"""
+        # Simple widget HTML — escape all dynamic values to prevent stored XSS
+        # from scraped movie titles persisted into weekly JSON.
+        list_items = "".join(
+            f"<li>{html.escape(str(m['title']))}</li>" for m in widget_data.movies[:5]
+        )
+        widget_html = f"""
         <div class="boxarr-widget">
             <h3>Box Office Week {widget_data.current_week}, {widget_data.current_year}</h3>
             <ol>
-                {"".join(f'<li>{m["title"]}</li>' for m in widget_data.movies[:5])}
+                {list_items}
             </ol>
-            <a href="{full_url}">View Full List</a>
+            <a href="{full_url_attr}">View Full List</a>
         </div>
         """
-        return HTMLResponse(content=html)
+        return HTMLResponse(content=widget_html)
     except Exception as e:
         logger.error(f"Error generating widget: {e}")
         return HTMLResponse(content="<div>Error loading widget</div>")

--- a/src/web/static/js/app.js
+++ b/src/web/static/js/app.js
@@ -248,7 +248,7 @@ function refreshSchedulerStatus() {
             // Update timezone
             const timezone = document.getElementById('debugTimezone');
             if (timezone) {
-                timezone.innerHTML = data.timezone || 'Unknown';
+                timezone.textContent = data.timezone || 'Unknown';
             }
         })
         .catch(error => {
@@ -1196,8 +1196,11 @@ function reloadScheduler() {
                         const currentValue = rootFolder.value; // Preserve current selection
                         rootFolder.innerHTML = '<option value="">Select root folder...</option>';
                         data.root_folders.forEach(folder => {
-                            const selected = folder.path === currentValue ? ' selected' : '';
-                            rootFolder.innerHTML += `<option value="${folder.path}"${selected}>${folder.path}</option>`;
+                            const option = document.createElement('option');
+                            option.value = folder.path;
+                            option.textContent = folder.path;
+                            if (folder.path === currentValue) option.selected = true;
+                            rootFolder.appendChild(option);
                         });
                     }
                 }
@@ -1210,8 +1213,11 @@ function reloadScheduler() {
                         const currentValue = defaultProfile.value; // Preserve current selection
                         defaultProfile.innerHTML = '<option value="">Select default quality...</option>';
                         data.profiles.forEach(profile => {
-                            const selected = profile.name === currentValue ? ' selected' : '';
-                            defaultProfile.innerHTML += `<option value="${profile.name}"${selected}>${profile.name}</option>`;
+                            const option = document.createElement('option');
+                            option.value = profile.name;
+                            option.textContent = profile.name;
+                            if (profile.name === currentValue) option.selected = true;
+                            defaultProfile.appendChild(option);
                         });
                     }
                     
@@ -1219,8 +1225,11 @@ function reloadScheduler() {
                         const currentValue = upgradeProfile.value; // Preserve current selection
                         upgradeProfile.innerHTML = '<option value="">Select upgrade quality...</option>';
                         data.profiles.forEach(profile => {
-                            const selected = profile.name === currentValue ? ' selected' : '';
-                            upgradeProfile.innerHTML += `<option value="${profile.name}"${selected}>${profile.name}</option>`;
+                            const option = document.createElement('option');
+                            option.value = profile.name;
+                            option.textContent = profile.name;
+                            if (profile.name === currentValue) option.selected = true;
+                            upgradeProfile.appendChild(option);
                         });
                     }
                 }
@@ -1234,7 +1243,10 @@ function reloadScheduler() {
                 if (saveBtn) saveBtn.disabled = true;
                 
                 if (testResults) {
-                    testResults.innerHTML = `<div class="error-message">✗ ${data.error || 'Connection failed'}</div>`;
+                    const errorDiv = document.createElement('div');
+                    errorDiv.className = 'error-message';
+                    errorDiv.textContent = `✗ ${data.error || 'Connection failed'}`;
+                    testResults.replaceChildren(errorDiv);
                     testResults.classList.add('error');
                 }
             }
@@ -1243,7 +1255,10 @@ function reloadScheduler() {
             if (testButton) testButton.textContent = 'Test Connection';
             if (testSpinner) testSpinner.style.display = 'none';
             if (testResults) {
-                testResults.innerHTML = `<div class="error-message">✗ Connection error: ${error.message}</div>`;
+                const errorDiv = document.createElement('div');
+                errorDiv.className = 'error-message';
+                errorDiv.textContent = `✗ Connection error: ${error.message}`;
+                testResults.replaceChildren(errorDiv);
                 testResults.classList.add('error');
             }
         });

--- a/src/web/templates/dashboard.html
+++ b/src/web/templates/dashboard.html
@@ -1785,10 +1785,13 @@ function showSuccess(message) {
     const progressFooter = document.getElementById('progressFooter');
     const progressSpinner = document.getElementById('progressSpinner');
     
-    progressMessage.innerHTML = `<span style="color: var(--success-color);">✅ ${message}</span>`;
+    const span = document.createElement('span');
+    span.style.color = 'var(--success-color)';
+    span.textContent = `✅ ${message}`;
+    progressMessage.replaceChildren(span);
     progressSpinner.style.display = 'none';
     progressFooter.style.display = 'block';
-    
+
     // Also add to log
     addToProgressLog(message, 'success');
 }
@@ -1799,10 +1802,13 @@ function showError(message) {
     const progressFooter = document.getElementById('progressFooter');
     const progressSpinner = document.getElementById('progressSpinner');
     
-    progressMessage.innerHTML = `<span style="color: var(--error-color);">❌ ${message}</span>`;
+    const span = document.createElement('span');
+    span.style.color = 'var(--error-color)';
+    span.textContent = `❌ ${message}`;
+    progressMessage.replaceChildren(span);
     progressSpinner.style.display = 'none';
     progressFooter.style.display = 'block';
-    
+
     // Also add to log
     addToProgressLog(message, 'error');
 }

--- a/tests/integration/test_widget_xss.py
+++ b/tests/integration/test_widget_xss.py
@@ -1,0 +1,60 @@
+"""Integration tests for stored XSS hardening in the /api/widget endpoint.
+
+Scraped Box Office Mojo titles are attacker-influenced input persisted into
+weekly JSON. The widget builds HTML by hand (not via autoescaped Jinja), so
+every dynamic value must be HTML-escaped before it reaches the browser.
+"""
+
+import json
+
+from fastapi.testclient import TestClient
+
+from src.api.app import create_app
+
+
+def _write_week(data_dir, title):
+    """Create a minimal weekly JSON fixture with a single movie title."""
+    weekly_pages = data_dir / "weekly_pages"
+    weekly_pages.mkdir(parents=True, exist_ok=True)
+    (weekly_pages / "2026W30.json").write_text(
+        json.dumps(
+            {
+                "year": 2026,
+                "week": 30,
+                "movies": [
+                    {"rank": 1, "title": title, "weekend_gross": 1000000},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_widget_escapes_stored_title(monkeypatch, tmp_path):
+    """A stored title with HTML must be escaped in the widget response."""
+    monkeypatch.setattr(
+        "src.api.routes.web.settings.boxarr_data_directory", str(tmp_path)
+    )
+    _write_week(tmp_path, "<script>alert(1)</script>")
+
+    client = TestClient(create_app())
+    response = client.get("/api/widget")
+
+    assert response.status_code == 200
+    assert "<script>alert(1)</script>" not in response.text
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in response.text
+
+
+def test_widget_escapes_title_attribute_breakers(monkeypatch, tmp_path):
+    """Quote/angle characters that could break out of markup are escaped."""
+    monkeypatch.setattr(
+        "src.api.routes.web.settings.boxarr_data_directory", str(tmp_path)
+    )
+    _write_week(tmp_path, '"><img src=x onerror=alert(1)>')
+
+    client = TestClient(create_app())
+    response = client.get("/api/widget")
+
+    assert response.status_code == 200
+    assert "<img src=x onerror=alert(1)>" not in response.text
+    assert "&lt;img src=x onerror=alert(1)&gt;" in response.text

--- a/tests/unit/test_template_innerhtml_xss.py
+++ b/tests/unit/test_template_innerhtml_xss.py
@@ -1,0 +1,27 @@
+"""Regression tests guarding against XSS-prone innerHTML sinks in templates.
+
+Server- and scraped-data values must reach the DOM via ``textContent`` (or a
+created element's ``textContent``), never interpolated into an ``innerHTML``
+string. The toast helpers in dashboard.html previously assigned
+``progressMessage.innerHTML`` with a template string embedding a server-supplied
+``message``; this asserts that pattern does not return.
+"""
+
+import re
+from pathlib import Path
+
+TEMPLATE_DIR = Path(__file__).resolve().parents[2] / "src" / "web" / "templates"
+
+# Matches an innerHTML assignment whose right-hand side interpolates a value
+# via a ${...} template placeholder (i.e. dynamic data injected as markup).
+INNERHTML_WITH_INTERPOLATION = re.compile(r"\.innerHTML\s*=\s*`[^`]*\$\{[^`]*`")
+
+
+def test_dashboard_has_no_interpolated_innerhtml():
+    """dashboard.html must not build innerHTML from interpolated values."""
+    content = (TEMPLATE_DIR / "dashboard.html").read_text(encoding="utf-8")
+    offenders = INNERHTML_WITH_INTERPOLATION.findall(content)
+    assert not offenders, (
+        "dashboard.html assigns innerHTML from an interpolated template "
+        f"string (use textContent instead): {offenders}"
+    )


### PR DESCRIPTION
## Problem

Boxarr rendered several pieces of externally-influenced data into the page without escaping, allowing HTML/JavaScript injection (stored XSS). Most notably, the public `/api/widget` endpoint built its HTML by hand and interpolated movie titles and the base URL directly. A malicious or unexpected movie title scraped from the Box Office source could break out of the markup and run arbitrary script in a viewer's browser. Because Boxarr is typically unauthenticated, this widget is exposed to anyone who can reach it.

Secondary sinks in the dashboard and setup UI wrote server-supplied strings (config-test error messages, Radarr root-folder / quality-profile names, scheduler timezone, and toast messages) into the DOM via `innerHTML`, giving the same injection surface.

## Root cause

Dynamic values were concatenated into HTML strings (server-side `HTMLResponse` in `/api/widget`, and client-side `element.innerHTML = ...` template literals) instead of being treated as text. The browser (or the response) then parsed attacker-controllable content as markup.

## Change

- `src/api/routes/web.py` (`/api/widget`): escape every dynamic value in the hand-built HTML — each movie title via `html.escape(str(m['title']))` and the base URL via `html.escape(full_url, quote=True)` for the `href` attribute. `current_week`/`current_year` are pydantic-validated ints and need no escaping. The JSON widget variant is untouched (no double-encoding).
- `src/web/templates/dashboard.html`: `showSuccess` / `showError` now build a `<span>`, set the emoji+message through `textContent`, and mount it with `replaceChildren(...)` instead of `innerHTML`. Visual output for benign messages is byte-identical.
- `src/web/static/js/app.js`: converted the config-test error messages, the Radarr root-folder and both quality-profile dropdowns, and the scheduler debug timezone from `innerHTML` string-building to `createElement` + `textContent` (+ `.value`/`.selected`).

Purely numeric/date sinks and admin-entered persisted config sinks were evaluated and left as-is; they are outside this scraped-data threat model.

## Testing

- `tests/integration/test_widget_xss.py` (2 tests): writes a weekly fixture with a malicious title and asserts `/api/widget` escapes both `<script>` and attribute-breaker payloads.
- `tests/unit/test_template_innerhtml_xss.py` (1 test): regression guard asserting `dashboard.html` contains no interpolated `.innerHTML = \`...${...}...\`` assignment.
- Full suite: 144 passed, 1 skipped (baseline 141 passed + 1 skipped; +3 new tests, 0 failures).
- `black --check`, `isort --check-only`, `flake8 --select=E9,F63,F7,F82 src/`, and `mypy src/ --ignore-missing-imports --no-strict-optional` all clean.


