### PR TITLE
fix: prevent charting sequels from matching the original film in the library

### DIFF
--- a/src/core/matcher.py
+++ b/src/core/matcher.py
@@ -205,6 +205,84 @@ class MovieMatcher:
 
         return base.strip()
 
+    def _sequel_marker(self, title: str) -> Optional[int]:
+        """
+        Extract an explicit trailing sequel marker as an integer.
+
+        Recognizes a trailing arabic number, a trailing Roman numeral, or a
+        trailing "Part N" (arabic, Roman, or number word). Returns None when
+        the title carries no such marker.
+
+        Args:
+            title: Movie title
+
+        Returns:
+            Sequel number or None
+        """
+        stripped = re.sub(r"\s*\(\d{4}\)\s*$", "", title).strip()
+
+        part_match = re.search(r"\bpart\s+(\w+)$", stripped, flags=re.IGNORECASE)
+        if part_match:
+            token = part_match.group(1)
+            if token.isdigit():
+                return int(token)
+            if token.upper() in self.ROMAN_NUMERALS:
+                return self.ROMAN_NUMERALS[token.upper()]
+            if token.lower() in self.WORD_TO_NUMBER:
+                return int(self.WORD_TO_NUMBER[token.lower()])
+            return None
+
+        num_match = re.search(r"\s+(\d+)$", stripped)
+        if num_match:
+            return int(num_match.group(1))
+
+        words = stripped.split()
+        if len(words) >= 2 and words[-1].upper() in self.ROMAN_NUMERALS:
+            return self.ROMAN_NUMERALS[words[-1].upper()]
+
+        return None
+
+    def _base_match_blocked(self, query_title: str, candidate: RadarrMovie) -> bool:
+        """
+        Decide whether a base-title/fuzzy match must be refused.
+
+        A query carrying an explicit sequel marker (e.g. "Gladiator II",
+        "Sonic the Hedgehog 3") must not collapse, via the digit/numeral
+        stripped base title, onto a library entry that lacks an equivalent
+        marker. Equivalence across marker forms is preserved ("Gladiator II"
+        still matches "Gladiator 2"), and a release-year match within one year
+        corroborates that the two titles are the same film.
+
+        Only the query-has-marker direction is guarded: a plain query is left
+        free to match a numbered library entry, since trailing numbers often
+        belong to the brand ("The Fantastic 4", "Ocean's 11") rather than a
+        sequel.
+
+        Args:
+            query_title: Box office title being matched
+            candidate: Candidate Radarr movie
+
+        Returns:
+            True if the match must be refused
+        """
+        query_marker = self._sequel_marker(query_title)
+        if query_marker is None:
+            return False
+
+        candidate_marker = self._sequel_marker(candidate.title)
+        if candidate_marker == query_marker:
+            return False
+
+        query_year = self.extract_year(query_title)
+        if (
+            query_year is not None
+            and candidate.year is not None
+            and abs(candidate.year - query_year) <= 1
+        ):
+            return False
+
+        return True
+
     def extract_year(self, title: str) -> Optional[int]:
         """
         Extract year from title if present.
@@ -385,7 +463,9 @@ class MovieMatcher:
         # Try base title
         base_title = self.get_base_title(title)
         if base_title.lower() in self._movie_cache:
-            return self._movie_cache[base_title.lower()]
+            candidate = self._movie_cache[base_title.lower()]
+            if not self._base_match_blocked(title, candidate):
+                return candidate
 
         # Try converting numbers to words and vice versa
         # This handles cases like "The Fantastic Four" vs "The Fantastic 4"
@@ -428,6 +508,11 @@ class MovieMatcher:
         normalized_title = self.normalize_title(title)
 
         for movie in radarr_movies:
+            # Skip candidates the query's sequel marker rules out, so a
+            # digit/numeral stripped base score cannot resurrect a wrong film.
+            if self._base_match_blocked(title, movie):
+                continue
+
             # Calculate various similarity scores
             exact_score = self.calculate_similarity(title, movie.title)
             normalized_score = self.calculate_similarity(

--- a/tests/unit/test_matcher_sequel_mismatch.py
+++ b/tests/unit/test_matcher_sequel_mismatch.py
@@ -1,0 +1,274 @@
+"""Regression tests for the sequel-vs-original matching defect.
+
+When a charting sequel is absent from the Radarr library but the original is
+present, the digit/numeral-stripped base-title fallback used to link the sequel
+to the original at high confidence, so auto-add skipped it and the weekly page
+showed the wrong film. These tests pin the fix and guard every intended
+equivalence that must survive it.
+"""
+
+from src.core.matcher import MovieMatcher
+from src.core.models import MovieStatus
+from src.core.radarr import RadarrMovie
+
+
+def _movie(id: int, title: str, year: int | None = None) -> RadarrMovie:
+    return RadarrMovie(
+        id=id,
+        title=title,
+        tmdbId=id * 1000,
+        year=year,
+        status=MovieStatus.RELEASED,
+        hasFile=False,
+    )
+
+
+class TestSequelDoesNotMatchOriginal:
+    """The reported defect: sequel query must not fall back to the original."""
+
+    def test_gladiator_two_does_not_match_gladiator_original(self):
+        """'Gladiator II' must NOT match a library holding only 'Gladiator' (2000)."""
+        library = [_movie(1, "Gladiator", 2000)]
+        matcher = MovieMatcher()  # production default (0.95)
+        matcher.build_movie_index(library)
+
+        result = matcher.match_single("Gladiator II", library)
+
+        assert not result.is_matched
+        assert result.radarr_movie is None
+
+    def test_gladiator_two_arabic_form_does_not_match_original(self):
+        """The arabic form 'Gladiator 2' is guarded the same as the Roman form."""
+        library = [_movie(1, "Gladiator", 2000)]
+        matcher = MovieMatcher()
+        matcher.build_movie_index(library)
+
+        result = matcher.match_single("Gladiator 2", library)
+
+        assert not result.is_matched
+
+    def test_sonic_three_does_not_match_sonic_original(self):
+        """'Sonic the Hedgehog 3' must NOT match 'Sonic the Hedgehog'."""
+        library = [_movie(1, "Sonic the Hedgehog", 2020)]
+        matcher = MovieMatcher()
+        matcher.build_movie_index(library)
+
+        result = matcher.match_single("Sonic the Hedgehog 3", library)
+
+        assert not result.is_matched
+
+    def test_part_marker_sequel_does_not_match_original(self):
+        """A 'Part N' marker is treated as an explicit sequel marker."""
+        library = [_movie(1, "Dune", 2021)]
+        matcher = MovieMatcher()
+        matcher.build_movie_index(library)
+
+        result = matcher.match_single("Dune Part Two", library)
+
+        assert not result.is_matched
+
+    def test_different_part_numbers_do_not_match(self):
+        """'Part 2' must not collapse onto a library 'Part 1'."""
+        library = [_movie(1, "Harry Potter and the Deathly Hallows: Part 1", 2010)]
+        matcher = MovieMatcher()
+        matcher.build_movie_index(library)
+
+        result = matcher.match_single(
+            "Harry Potter and the Deathly Hallows: Part 2", library
+        )
+
+        assert not result.is_matched
+
+    def test_low_threshold_still_refuses_sequel_to_original(self):
+        """Even a permissive fuzzy threshold must not resurrect the original."""
+        library = [_movie(1, "Gladiator", 2000)]
+        matcher = MovieMatcher(min_confidence=0.8)
+        matcher.build_movie_index(library)
+
+        result = matcher.match_single("Gladiator II", library)
+
+        assert not result.is_matched
+
+
+class TestMarkerEquivalenceStillMatches:
+    """Roman<->arabic equivalence between sequels must keep working."""
+
+    def test_gladiator_roman_matches_arabic_sequel(self):
+        """'Gladiator II' matches library 'Gladiator 2' (same film, different form)."""
+        library = [_movie(1, "Gladiator", 2000), _movie(2, "Gladiator 2", 2024)]
+        matcher = MovieMatcher()
+        matcher.build_movie_index(library)
+
+        result = matcher.match_single("Gladiator II", library)
+
+        assert result.is_matched
+        assert result.radarr_movie.title == "Gladiator 2"
+
+    def test_gladiator_arabic_matches_arabic_sequel(self):
+        """'Gladiator 2' matches library 'Gladiator 2' when both originals exist."""
+        library = [_movie(1, "Gladiator", 2000), _movie(2, "Gladiator 2", 2024)]
+        matcher = MovieMatcher()
+        matcher.build_movie_index(library)
+
+        result = matcher.match_single("Gladiator 2", library)
+
+        assert result.is_matched
+        assert result.radarr_movie.title == "Gladiator 2"
+
+    def test_frozen_arabic_matches_roman_sequel(self):
+        """'Frozen 2' matches library 'Frozen II' (the documented equivalence)."""
+        library = [_movie(1, "Frozen II", 2019)]
+        matcher = MovieMatcher()
+        matcher.build_movie_index(library)
+
+        result = matcher.match_single("Frozen 2", library)
+
+        assert result.is_matched
+        assert result.radarr_movie.title == "Frozen II"
+
+    def test_frozen_roman_matches_arabic_sequel(self):
+        """'Frozen II' matches library 'Frozen 2' (reverse form equivalence)."""
+        library = [_movie(1, "Frozen 2", 2019)]
+        matcher = MovieMatcher()
+        matcher.build_movie_index(library)
+
+        result = matcher.match_single("Frozen II", library)
+
+        assert result.is_matched
+        assert result.radarr_movie.title == "Frozen 2"
+
+    def test_part_two_matches_part_ii_equivalent(self):
+        """'... Part Two' matches a library '... Part 2' via equivalent markers."""
+        library = [_movie(1, "The Hunger Games: Mockingjay - Part 2", 2015)]
+        matcher = MovieMatcher()
+        matcher.build_movie_index(library)
+
+        result = matcher.match_single(
+            "The Hunger Games: Mockingjay - Part Two", library
+        )
+
+        assert result.is_matched
+        assert result.radarr_movie.title == "The Hunger Games: Mockingjay - Part 2"
+
+    def test_correct_sequel_preferred_when_both_present(self):
+        """With original and sequel present, the sequel query picks the sequel."""
+        library = [
+            _movie(1, "Sonic the Hedgehog", 2020),
+            _movie(2, "Sonic the Hedgehog 3", 2024),
+        ]
+        matcher = MovieMatcher()
+        matcher.build_movie_index(library)
+
+        result = matcher.match_single("Sonic the Hedgehog 3", library)
+
+        assert result.is_matched
+        assert result.radarr_movie.title == "Sonic the Hedgehog 3"
+
+
+class TestYearCorroboration:
+    """A release-year match within one year overrides the marker guard."""
+
+    def test_same_year_corroborates_same_film(self):
+        """Matching years mean the marker mismatch is treated as the same film."""
+        library = [_movie(1, "Gladiator", 2000)]
+        matcher = MovieMatcher()
+        matcher.build_movie_index(library)
+
+        # A charting entry re-released the same year as the library entry.
+        result = matcher.match_single("Gladiator II (2000)", library)
+
+        assert result.is_matched
+        assert result.radarr_movie.title == "Gladiator"
+
+    def test_year_within_one_corroborates(self):
+        """A one-year gap still corroborates (boundary, inclusive)."""
+        library = [_movie(1, "Gladiator", 2000)]
+        matcher = MovieMatcher()
+        matcher.build_movie_index(library)
+
+        result = matcher.match_single("Gladiator II (2001)", library)
+
+        assert result.is_matched
+        assert result.radarr_movie.title == "Gladiator"
+
+    def test_year_gap_of_two_does_not_corroborate(self):
+        """A two-year gap is outside the window and the guard holds."""
+        library = [_movie(1, "Gladiator", 2000)]
+        matcher = MovieMatcher()
+        matcher.build_movie_index(library)
+
+        result = matcher.match_single("Gladiator II (2002)", library)
+
+        assert not result.is_matched
+
+    def test_real_sequel_year_does_not_corroborate(self):
+        """The real 'Gladiator II' (2024) never corroborates 'Gladiator' (2000)."""
+        library = [_movie(1, "Gladiator", 2000)]
+        matcher = MovieMatcher()
+        matcher.build_movie_index(library)
+
+        result = matcher.match_single("Gladiator II (2024)", library)
+
+        assert not result.is_matched
+
+
+class TestUnmarkedBehaviorPreserved:
+    """Behaviors without an explicit query marker must be untouched."""
+
+    def setup_method(self):
+        self.matcher = MovieMatcher(min_confidence=0.8)
+        self.library = [
+            _movie(1, "Spider-Man: No Way Home", 2021),
+            _movie(2, "The Batman", 2022),
+            _movie(3, "Batman", 1989),
+            _movie(4, "The Dark Knight", 2008),
+            _movie(5, "The Fantastic 4: First Steps", 2025),
+            _movie(6, "Ocean's 11", 2001),
+            _movie(7, "Wicked", 2024),
+        ]
+        self.matcher.build_movie_index(self.library)
+
+    def test_exact_match_preserved(self):
+        result = self.matcher.match_single("Wicked", self.library)
+        assert result.is_matched
+        assert result.match_method == "exact"
+
+    def test_the_batman_prefers_the_batman(self):
+        """'The Batman' handling stays as documented."""
+        result = self.matcher.match_single("The Batman", self.library)
+        assert result.is_matched
+        assert result.radarr_movie.title == "The Batman"
+
+    def test_batman_without_article_matches_older_batman(self):
+        result = self.matcher.match_single("Batman", self.library)
+        assert result.is_matched
+        assert result.radarr_movie.title == "Batman"
+        assert result.radarr_movie.year == 1989
+
+    def test_dark_knight_matches_the_dark_knight(self):
+        result = self.matcher.match_single("Dark Knight", self.library)
+        assert result.is_matched
+        assert result.radarr_movie.title == "The Dark Knight"
+
+    def test_brand_number_in_library_still_matches_word_query(self):
+        """A plain word query still reaches a numbered brand title ('Fantastic 4')."""
+        result = self.matcher.match_single(
+            "The Fantastic Four: First Steps", self.library
+        )
+        assert result.is_matched
+        assert result.radarr_movie.title == "The Fantastic 4: First Steps"
+
+    def test_word_form_query_matches_numbered_brand(self):
+        """'Ocean's Eleven' still matches library 'Ocean's 11' (number is brand)."""
+        result = self.matcher.match_single("Ocean's Eleven", self.library)
+        assert result.is_matched
+        assert result.radarr_movie.title == "Ocean's 11"
+
+    def test_fuzzy_typo_still_matches(self):
+        result = self.matcher.match_single("Spiderman: No Way Home", self.library)
+        assert result.is_matched
+        assert result.radarr_movie.title == "Spider-Man: No Way Home"
+
+    def test_unrelated_title_still_no_match(self):
+        result = self.matcher.match_single("Some Nonexistent Film", self.library)
+        assert not result.is_matched


### PR DESCRIPTION
## Problem

When a charting film was a sequel that was not yet in the Radarr library (e.g. `Gladiator II`, `Sonic the Hedgehog 3`, `Dune: Part Two`, `Zootopia 2`), Boxarr incorrectly matched it — at high confidence — to the *original* film already in the library (`Gladiator`, `Sonic the Hedgehog`, `Dune`, `Zootopia`). As a result the sequel was skipped by auto-add and the weekly box-office page displayed the wrong film.

## Root cause

`get_base_title()` strips a trailing arabic number and a trailing Roman numeral to produce a base title. In `_try_normalized_match`, the base-title fallback matched the stripped query (`Gladiator 2` -> `gladiator`) against the base-title index, which points at the non-sequel original. The fuzzy path had the same hole via `base_score`, which collapses both sides to the same base title (`base_score = 1.0` for `Gladiator II` vs `Gladiator`).

## Change

In `src/core/matcher.py`:

1. `_sequel_marker(title)` — extracts an explicit trailing sequel marker (arabic number, Roman numeral value, or `Part N` in arabic / Roman / word form). A trailing `(YYYY)` year parenthetical is stripped first so the marker is still detected when a year is appended.
2. `_base_match_blocked(query_title, candidate)` — refuses a base/fuzzy match when the query carries a sequel marker the candidate does not share. Marker-form equivalence (`II` == `2`) is allowed, and a release-year match within one year corroborates same-film and is also allowed.
3. The guard is applied at the base-title fallback in `_try_normalized_match` and per-candidate at the top of the `_try_fuzzy_match` loop.

Only the query-has-marker direction is guarded. A plain query with no marker is left free to reach a numbered library entry, because trailing numbers frequently belong to the brand (`The Fantastic 4`, `Ocean's 11`) rather than denoting a sequel; guarding that direction would break existing word<->number equivalences. Intended equivalences (`Gladiator II` <-> `Gladiator 2`, `Frozen II` <-> `Frozen 2`, `Part Two` -> `Part 2`, article variations, fuzzy typo threshold, brand-number word queries) are preserved.

## Testing

- New `tests/unit/test_matcher_sequel_mismatch.py` (24 tests): negative cases fail without the fix (they match on `main`) and pass with it; intended equivalences and unmarked-brand behavior are asserted preserved.
- Full suite: 165 passed, 1 skipped, 0 failures (141 baseline + 24 new).
- `black --check`, `isort --check-only`, `flake8 --select=E9,F63,F7,F82 src/`, `mypy src/ --ignore-missing-imports --no-strict-optional`: all clean.

