### PR TITLE
fix: harden config load/save against corrupt local.yaml

### DIFF
--- a/src/api/routes/config.py
+++ b/src/api/routes/config.py
@@ -303,11 +303,21 @@ async def save_configuration(config: SaveConfigRequest):
             },
         }
 
-        # Save to local.yaml
+        # Save to local.yaml atomically (temp file + os.replace) so an
+        # interrupted write cannot truncate local.yaml and brick startup.
+        import tempfile
+
         import yaml
 
-        with open(config_path, "w") as f:
-            yaml.dump(config_data, f, default_flow_style=False)
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_fd, tmp_path = tempfile.mkstemp(dir=config_path.parent, suffix=".tmp")
+        try:
+            with open(tmp_fd, "w") as f:
+                yaml.dump(config_data, f, default_flow_style=False)
+            os.replace(tmp_path, config_path)
+        except Exception:
+            Path(tmp_path).unlink(missing_ok=True)
+            raise
 
         logger.info("Configuration saved successfully")
 

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,13 +1,19 @@
 """Configuration management for Boxarr using pydantic-settings."""
 
 import os
+import shutil
+from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 import yaml
-from pydantic import BaseModel, Field, HttpUrl, validator
+from pydantic import BaseModel, Field, HttpUrl, ValidationError, validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from .logger import get_logger
+
+logger = get_logger(__name__)
 
 
 class ThemeEnum(str, Enum):
@@ -348,6 +354,26 @@ class Settings(BaseSettings):
                 env_set.add(field_name)
         return env_set
 
+    @staticmethod
+    def _backup_broken_config(config_path: Path) -> None:
+        """Copy an unreadable config file aside so user data survives.
+
+        The copy preserves the original so a later ``save_configuration`` that
+        overwrites ``local.yaml`` does not destroy the user's settings. When a
+        ``.broken`` backup already exists, a timestamp suffix keeps each one.
+        """
+        backup = config_path.with_suffix(config_path.suffix + ".broken")
+        if backup.exists():
+            timestamp = datetime.now().strftime("%Y%m%d%H%M%S")
+            backup = config_path.with_suffix(
+                config_path.suffix + f".broken.{timestamp}"
+            )
+        try:
+            shutil.copy2(config_path, backup)
+            logger.error("Backed up unreadable config to %s", backup)
+        except OSError as exc:
+            logger.error("Could not back up unreadable config %s: %s", config_path, exc)
+
     def load_from_yaml(
         self,
         config_path: Path,
@@ -363,12 +389,43 @@ class Settings(BaseSettings):
         protected = env_protected_fields or set()
 
         def _safe_setattr(field: str, value: Any) -> None:
-            if field not in protected:
-                setattr(self, field, value)
+            if field in protected:
+                return
+            try:
+                self.__pydantic_validator__.validate_assignment(self, field, value)
+            except ValidationError as exc:
+                logger.warning(
+                    "Ignoring invalid value for '%s' in %s (using default): %s",
+                    field,
+                    config_path,
+                    exc,
+                )
 
         if config_path.exists():
-            with open(config_path) as f:
-                config_data = yaml.safe_load(f) or {}
+            try:
+                with open(config_path) as f:
+                    config_data = yaml.safe_load(f) or {}
+            except yaml.YAMLError as exc:
+                logger.error(
+                    "!!! Could not parse configuration file %s: %s. "
+                    "Backing up the unreadable file and starting with defaults "
+                    "(setup mode).",
+                    config_path,
+                    exc,
+                )
+                self._backup_broken_config(config_path)
+                return
+
+            if not isinstance(config_data, dict):
+                logger.error(
+                    "!!! Configuration file %s did not contain a mapping "
+                    "(got %s). Backing it up and starting with defaults "
+                    "(setup mode).",
+                    config_path,
+                    type(config_data).__name__,
+                )
+                self._backup_broken_config(config_path)
+                return
 
             # Process configuration sections
             for section, values in config_data.items():

--- a/tests/integration/test_config_atomic_save.py
+++ b/tests/integration/test_config_atomic_save.py
@@ -1,0 +1,116 @@
+"""Integration test for atomic configuration saves.
+
+An interrupted write must never truncate ``local.yaml`` and brick the next
+startup. The save writes to a temp file and swaps it in with ``os.replace``, so
+a failure during the swap leaves the previous config intact and leaves no
+partial ``.tmp`` file behind.
+"""
+
+from pathlib import Path
+
+import yaml
+from fastapi.testclient import TestClient
+
+from src.api.app import create_app
+
+
+class _FakeRadarrService:
+    def __init__(self, *_, **__):
+        pass
+
+    def test_connection(self) -> bool:
+        return True
+
+
+def _write_initial_config(dir_path: Path) -> Path:
+    cfg = {
+        "radarr": {
+            "url": "http://localhost:7878",
+            "api_key": "original-key",
+            "root_folder": "/movies",
+            "quality_profile_default": "HD-1080p",
+        },
+        "boxarr": {
+            "scheduler": {"enabled": False, "cron": "0 23 * * 1"},
+            "features": {"auto_add": False, "quality_upgrade": True},
+            "ui": {"theme": "light"},
+        },
+    }
+    p = dir_path / "local.yaml"
+    with open(p, "w") as f:
+        yaml.safe_dump(cfg, f)
+    return p
+
+
+def _payload() -> dict:
+    return {
+        "radarr_url": "http://localhost:7878",
+        "radarr_api_key": "new-key",
+        "radarr_root_folder": "/movies",
+        "radarr_quality_profile_default": "HD-1080p",
+        "radarr_quality_profile_upgrade": "",
+        "boxarr_scheduler_enabled": False,
+        "boxarr_scheduler_cron": "0 23 * * 1",
+        "boxarr_features_auto_add": False,
+        "boxarr_features_quality_upgrade": True,
+        "boxarr_features_auto_add_limit": 10,
+        "boxarr_features_auto_add_genre_filter_enabled": False,
+        "boxarr_features_auto_add_genre_filter_mode": "blacklist",
+        "boxarr_features_auto_add_genre_whitelist": [],
+        "boxarr_features_auto_add_genre_blacklist": [],
+        "boxarr_features_auto_add_rating_filter_enabled": False,
+        "boxarr_features_auto_add_rating_whitelist": [],
+        "boxarr_ui_theme": "light",
+    }
+
+
+def test_interrupted_save_does_not_truncate_config(tmp_path, monkeypatch):
+    """A failure during the atomic swap leaves the original file intact."""
+    monkeypatch.setenv("BOXARR_DATA_DIRECTORY", str(tmp_path))
+    _write_initial_config(tmp_path)
+
+    import src.api.routes.config as cfg_routes
+
+    monkeypatch.setattr(cfg_routes, "RadarrService", _FakeRadarrService)
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("simulated crash during replace")
+
+    monkeypatch.setattr(cfg_routes.os, "replace", _boom)
+
+    app = create_app()
+    client = TestClient(app)
+
+    resp = client.post("/api/config/save", json=_payload())
+    assert resp.status_code == 200
+    assert resp.json().get("success") is False
+
+    # Original config is intact and still valid YAML (not truncated)
+    with open(tmp_path / "local.yaml") as f:
+        current = yaml.safe_load(f)
+    assert current["radarr"]["api_key"] == "original-key"
+
+    # No partial temp file left behind
+    assert list(tmp_path.glob("*.tmp")) == []
+
+
+def test_successful_save_replaces_config_atomically(tmp_path, monkeypatch):
+    """A normal save writes the new values and leaves no temp files."""
+    monkeypatch.setenv("BOXARR_DATA_DIRECTORY", str(tmp_path))
+    _write_initial_config(tmp_path)
+
+    import src.api.routes.config as cfg_routes
+
+    monkeypatch.setattr(cfg_routes, "RadarrService", _FakeRadarrService)
+
+    app = create_app()
+    client = TestClient(app)
+
+    resp = client.post("/api/config/save", json=_payload())
+    assert resp.status_code == 200
+    assert resp.json().get("success") is True
+
+    with open(tmp_path / "local.yaml") as f:
+        current = yaml.safe_load(f)
+    assert current["radarr"]["api_key"] == "new-key"
+    assert list(tmp_path.glob("*.tmp")) == []

--- a/tests/unit/test_config_resilience.py
+++ b/tests/unit/test_config_resilience.py
@@ -1,0 +1,161 @@
+"""Tests for configuration loading resilience.
+
+A malformed or wrong-typed ``local.yaml`` must never crash startup. The loader
+should back up the unreadable file and boot with defaults (setup mode), and it
+should skip individual values that fail validation rather than aborting.
+Related: hardening for v1.8.0.
+"""
+
+import os
+import textwrap
+from pathlib import Path
+
+from src.utils.config import Settings, load_settings
+
+
+def _write(path: Path, text: str) -> None:
+    path.write_text(textwrap.dedent(text))
+
+
+class TestMalformedConfigFallsBackToDefaults:
+    """A file that cannot be parsed must not raise; defaults are used."""
+
+    def test_malformed_yaml_returns_defaults_and_backs_up(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("BOXARR_DATA_DIRECTORY", str(tmp_path))
+        config_file = tmp_path / "local.yaml"
+        # Unbalanced brackets -> yaml.YAMLError on parse
+        config_file.write_text("radarr: {api_key: 'oops\nboxarr: [1, 2, ,")
+
+        settings = load_settings()
+
+        # Booted with defaults, no exception raised
+        assert settings.radarr_api_key == ""
+        assert settings.boxarr_port == 8888
+
+        # Original file preserved as a .broken backup so user data survives
+        backup = tmp_path / "local.yaml.broken"
+        assert backup.exists()
+        assert config_file.exists()
+
+    def test_non_mapping_yaml_returns_defaults_and_backs_up(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("BOXARR_DATA_DIRECTORY", str(tmp_path))
+        config_file = tmp_path / "local.yaml"
+        # Valid YAML, but a list rather than the expected mapping
+        _write(
+            config_file,
+            """\
+            - just
+            - a
+            - list
+            """,
+        )
+
+        settings = load_settings()
+
+        assert settings.radarr_api_key == ""
+        assert (tmp_path / "local.yaml.broken").exists()
+
+    def test_second_broken_backup_is_timestamped(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        monkeypatch.setenv("BOXARR_DATA_DIRECTORY", str(tmp_path))
+        config_file = tmp_path / "local.yaml"
+        (tmp_path / "local.yaml.broken").write_text("previous backup")
+        config_file.write_text("radarr: {api_key: 'oops\n[")
+
+        load_settings()
+
+        # Existing .broken preserved; a timestamped copy added alongside it
+        timestamped = list(tmp_path.glob("local.yaml.broken.*"))
+        assert (tmp_path / "local.yaml.broken").read_text() == "previous backup"
+        assert len(timestamped) == 1
+
+
+class TestValidConfigStillLoads:
+    """Regression: a well-formed file must load all values as before."""
+
+    def test_valid_config_applies_all_values(self, tmp_path: Path) -> None:
+        env_clean = {
+            k: v
+            for k, v in os.environ.items()
+            if k
+            not in (
+                "BOXARR_PORT",
+                "PORT",
+                "RADARR_API_KEY",
+                "RADARR_TIMEOUT",
+                "LOG_LEVEL",
+            )
+        }
+        from unittest.mock import patch
+
+        with patch.dict(os.environ, env_clean, clear=True):
+            config_file = tmp_path / "local.yaml"
+            _write(
+                config_file,
+                """\
+                radarr:
+                  api_key: my-key-42
+                  timeout: 45
+                boxarr:
+                  port: 9191
+                  scheduler:
+                    cron: "0 12 * * 3"
+                  features:
+                    box_office_limit: 15
+                log_level: DEBUG
+                """,
+            )
+            settings = Settings(boxarr_data_directory=tmp_path)
+            settings.load_from_yaml(config_file)
+
+            assert settings.radarr_api_key == "my-key-42"
+            assert settings.radarr_timeout == 45
+            assert settings.boxarr_port == 9191
+            assert settings.boxarr_scheduler_cron == "0 12 * * 3"
+            assert settings.boxarr_features_box_office_limit == 15
+            assert settings.log_level == "DEBUG"
+
+
+class TestWrongTypedValueIsSkipped:
+    """A single invalid value is skipped; the rest of the file still loads."""
+
+    def test_invalid_value_keeps_default_and_loads_siblings(
+        self, tmp_path: Path
+    ) -> None:
+        config_file = tmp_path / "local.yaml"
+        _write(
+            config_file,
+            """\
+            radarr:
+              api_key: good-key
+              timeout: not-a-number
+            """,
+        )
+        settings = Settings(boxarr_data_directory=tmp_path)
+        settings.load_from_yaml(config_file)
+
+        # Invalid timeout skipped -> field keeps its default
+        assert settings.radarr_timeout == 120.0
+        # Sibling value in the same section still applied
+        assert settings.radarr_api_key == "good-key"
+
+    def test_out_of_range_value_keeps_default(self, tmp_path: Path) -> None:
+        config_file = tmp_path / "local.yaml"
+        _write(
+            config_file,
+            """\
+            boxarr:
+              features:
+                box_office_limit: 999
+            """,
+        )
+        settings = Settings(boxarr_data_directory=tmp_path)
+        settings.load_from_yaml(config_file)
+
+        # 999 exceeds the le=30 constraint -> skipped, default retained
+        assert settings.boxarr_features_box_office_limit == 10


### PR DESCRIPTION
## Problem

If Boxarr's `local.yaml` becomes malformed — a partial/truncated write, a hand-edit typo, or an interrupted save — the app failed to start. On startup it would raise on the unparseable YAML instead of falling back gracefully, so a single bad config file could brick the whole application with no easy recovery path for the user.

## Root cause

Two gaps in the config path:

1. **Load** (`Settings.load_from_yaml`): `yaml.safe_load` was called with no error handling, so any `YAMLError` (or a valid-YAML-but-non-mapping file) propagated out and aborted startup. Individual bad/out-of-range values also had no per-key guard.
2. **Save** (`save_configuration`): the config was written with a plain `open(path, "w")` + `yaml.dump`. An interrupted write truncates `local.yaml` in place, leaving a corrupt file behind — which then triggers the load failure above on the next boot.

## Change

**Load guard** (`src/utils/config.py`): `yaml.safe_load` is wrapped in `try/except yaml.YAMLError`. On a parse error — or a valid-YAML-but-non-mapping file — the loader logs a loud, actionable error naming the file and the parse error, backs the unreadable file up to `local.yaml.broken` (timestamp-suffixed when a prior `.broken` exists, so user data is never silently overwritten), and returns early so the app boots with defaults into setup mode, exactly as if `local.yaml` were missing. Per-value handling now routes `_safe_setattr` through pydantic `validate_assignment`: an invalid/out-of-range single value is logged and left at its default while the rest of the file loads.

**Atomic save** (`src/api/routes/config.py`): the write now goes to a `tempfile.mkstemp` file in the same directory, followed by `os.replace` (atomic rename), with the temp file unlinked on failure — mirroring the existing `ignore_list.py` `_save` pattern. An interrupted write can no longer truncate `local.yaml`.

## Testing

- `tests/unit/test_config_resilience.py` (6 tests): malformed YAML falls back to defaults and creates `.broken`; non-mapping YAML falls back; a second corruption produces a timestamped backup; a valid file still loads every value (regression); a wrong-typed value is skipped while siblings load; an out-of-range value keeps its default.
- `tests/integration/test_config_atomic_save.py` (2 tests): `os.replace` patched to raise mid-save leaves the original `local.yaml` intact and valid with no leftover `.tmp`; plus a successful-save case.
- Full suite: 149 passed, 1 skipped (141 baseline + 8 new). `black`, `isort`, `flake8` (E9/F63/F7/F82), and `mypy` all clean.

