### PR TITLE
fix: harden weekly JSON integrity (atomic writes, corruption-safe reads, un-linking)

### DIFF
--- a/src/api/routes/admin.py
+++ b/src/api/routes/admin.py
@@ -11,6 +11,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from ...core.radarr import RadarrService
+from ...utils.atomic import atomic_write_json
 from ...utils.config import settings
 from ...utils.logger import get_logger
 
@@ -291,8 +292,7 @@ async def repair_missing_metadata(request: RepairRequest):
 
                     if updated:
                         # Save the updated file
-                        with open(json_file, "w") as f:
-                            json.dump(data, f, indent=2, default=str)
+                        atomic_write_json(json_file, data, indent=2, default=str)
                         updated_weeks += 1
                         logger.info(f"Updated week file: {week_key}")
 

--- a/src/api/routes/movies.py
+++ b/src/api/routes/movies.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 
 from ...core.ignore_list import IgnoreList
 from ...core.json_generator import WeeklyDataGenerator
-from ...core.library_sync import refresh_weekly_data_from_radarr
+from ...core.library_sync import WEEKLY_WRITE_LOCK, refresh_weekly_data_from_radarr
 from ...core.models import MovieStatus
 from ...core.radarr import RadarrService, get_all_movies_with_optional_cache_bypass
 from ...core.root_folder_manager import RootFolderManager
@@ -187,6 +187,16 @@ async def unignore_movie(tmdb_id: int):
 
 def _run_refresh_job() -> None:
     """Synchronous worker that runs in a thread and updates _refresh_state."""
+    if not WEEKLY_WRITE_LOCK.acquire(blocking=False):
+        logger.warning("Another weekly update is in progress; skipping refresh")
+        _refresh_state.update(
+            {
+                "running": False,
+                "complete": False,
+                "error": "Another weekly update is in progress",
+            }
+        )
+        return
     try:
 
         def _progress(scanned: int, total: int, updated: int, refreshed: int) -> None:
@@ -213,6 +223,8 @@ def _run_refresh_job() -> None:
     except Exception as exc:
         logger.error(f"Error in background refresh job: {exc}")
         _refresh_state.update({"running": False, "complete": False, "error": str(exc)})
+    finally:
+        WEEKLY_WRITE_LOCK.release()
 
 
 @router.post("/refresh-stored-status")

--- a/src/api/routes/scheduler.py
+++ b/src/api/routes/scheduler.py
@@ -9,6 +9,7 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from ...core.library_sync import WEEKLY_WRITE_LOCK
 from ...core.scheduler import BoxarrScheduler
 from ...utils.config import settings
 from ...utils.logger import get_logger
@@ -270,6 +271,34 @@ async def update_specific_week(request: UpdateWeekRequest):  # noqa: C901
         if week < 1 or week > 53:
             raise HTTPException(status_code=400, detail="Invalid week number")
 
+        # Offload the blocking scrape + file write to a worker thread so the
+        # event loop stays responsive (#114). The weekly-JSON write lock is
+        # acquired inside that worker (never held across an await) to serialize
+        # against the other weekly-JSON mutators (#120).
+        return await asyncio.to_thread(_update_specific_week, year, week)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error updating week: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+def _update_specific_week(year: int, week: int) -> dict:  # noqa: C901
+    """Fetch, match and persist box office data for one week.
+
+    Runs in a worker thread (via ``asyncio.to_thread`` from the async endpoint),
+    so the process-wide weekly-JSON write lock is acquired here in the worker
+    thread rather than across an await. Fails fast if another weekly-JSON
+    mutator already holds the lock instead of racing writes to the same file.
+    """
+    # Serialize against other weekly-JSON mutators; fail fast if one is
+    # already running rather than racing writes to the same file.
+    if not WEEKLY_WRITE_LOCK.acquire(blocking=False):
+        return {
+            "success": False,
+            "message": "Another update is in progress, please retry shortly",
+        }
+    try:
         from ...core.boxoffice import BoxOfficeService
         from ...core.json_generator import WeeklyDataGenerator
         from ...core.matcher import MovieMatcher
@@ -281,8 +310,8 @@ async def update_specific_week(request: UpdateWeekRequest):  # noqa: C901
         # Get box office data
         boxoffice_service = BoxOfficeService()
         limit = settings.boxarr_features_box_office_limit
-        box_office_movies = await asyncio.to_thread(
-            boxoffice_service.fetch_weekend_box_office, year, week, limit=limit
+        box_office_movies = boxoffice_service.fetch_weekend_box_office(
+            year, week, limit=limit
         )
 
         if not box_office_movies:
@@ -349,8 +378,5 @@ async def update_specific_week(request: UpdateWeekRequest):  # noqa: C901
             "movies_found": len(box_office_movies),
             "movies_added": added_count,
         }
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error(f"Error updating week: {e}")
-        raise HTTPException(status_code=500, detail=str(e))
+    finally:
+        WEEKLY_WRITE_LOCK.release()

--- a/src/api/routes/web.py
+++ b/src/api/routes/web.py
@@ -602,9 +602,15 @@ async def serve_weekly_page(request: Request, year: int, week: int):
     if not json_file.exists():
         raise HTTPException(status_code=404, detail="Week not found")
 
-    # Load week data
-    with open(json_file) as f:
-        metadata = json.load(f)
+    # Load week data — a truncated/corrupt file degrades to a 404 instead of a 500
+    try:
+        with open(json_file) as f:
+            metadata = json.load(f)
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.error(f"Could not read weekly data for {year}W{week:02d}: {exc}")
+        raise HTTPException(
+            status_code=404, detail="Week data is unavailable or corrupted"
+        )
 
     movies = metadata.get("movies", [])
 
@@ -821,27 +827,32 @@ async def get_widget_data() -> WidgetData:
     """Get current week widget data."""
     weekly_pages_dir = Path(settings.boxarr_data_directory) / "weekly_pages"
 
-    # Find most recent week
+    # Find most recent week, skipping any unreadable/corrupt files
     json_files = sorted(weekly_pages_dir.glob("*.json"), reverse=True)
-    if not json_files:
-        return WidgetData(
-            current_week=0,
-            current_year=datetime.now().year,
-            movies=[],
-        )
-
-    with open(json_files[0]) as f:
-        metadata = json.load(f)
+    for json_file in json_files:
+        if json_file.name == "current.json":
+            continue
+        try:
+            with open(json_file) as f:
+                metadata = json.load(f)
+            return WidgetData(
+                current_week=metadata["week"],
+                current_year=metadata["year"],
+                movies=[
+                    {
+                        "rank": m.get("rank"),
+                        "title": m.get("title"),
+                        "gross": m.get("weekend_gross"),
+                    }
+                    for m in metadata.get("movies", [])[:10]
+                ],
+            )
+        except (json.JSONDecodeError, OSError, KeyError) as exc:
+            logger.warning(f"Skipping unreadable widget data file {json_file}: {exc}")
+            continue
 
     return WidgetData(
-        current_week=metadata["week"],
-        current_year=metadata["year"],
-        movies=[
-            {
-                "rank": m.get("rank"),
-                "title": m.get("title"),
-                "gross": m.get("weekend_gross"),
-            }
-            for m in metadata.get("movies", [])[:10]
-        ],
+        current_week=0,
+        current_year=datetime.now().year,
+        movies=[],
     )

--- a/src/core/json_generator.py
+++ b/src/core/json_generator.py
@@ -1,10 +1,10 @@
 """JSON data generator for weekly box office pages."""
 
-import json
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from ..utils.atomic import atomic_write_json
 from ..utils.config import settings
 from ..utils.logger import get_logger
 from .matcher import MatchResult
@@ -231,8 +231,7 @@ class WeeklyDataGenerator:
 
         # Save JSON file
         metadata_path = self.output_dir / f"{year}W{week:02d}.json"
-        with open(metadata_path, "w") as f:
-            json.dump(metadata, f, indent=2)
+        atomic_write_json(metadata_path, metadata, indent=2)
 
         logger.info(f"Generated weekly data: {metadata_path}")
         return metadata_path

--- a/src/core/library_sync.py
+++ b/src/core/library_sync.py
@@ -1,10 +1,12 @@
 """Helpers for refreshing stored weekly movie data from Radarr."""
 
 import json
+import threading
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from ..utils.atomic import atomic_write_json
 from ..utils.config import settings
 from ..utils.logger import get_logger
 from .models import MovieStatus
@@ -15,6 +17,28 @@ from .radarr import (
 )
 
 logger = get_logger(__name__)
+
+# Process-wide guard serializing every path that rewrites weekly_pages/*.json:
+# the scheduled cron update, the manual /api/scheduler/trigger, the button
+# refresh background job, and /update-week. Callers acquire it around their
+# whole mutation; the writers it protects never re-acquire it, so it cannot
+# deadlock. A second caller that cannot acquire it fails fast.
+WEEKLY_WRITE_LOCK = threading.Lock()
+
+# Fields reset when a stored movie's Radarr link no longer resolves (the movie
+# was deleted in Radarr). Display metadata (title, tmdb_id, year, poster, …) is
+# intentionally left untouched.
+_UNLINKED_FIELDS: Dict[str, Any] = {
+    "radarr_id": None,
+    "radarr_title": None,
+    "status": "Not in Radarr",
+    "status_color": "#718096",
+    "status_icon": "➕",
+    "quality_profile_id": None,
+    "quality_profile_name": None,
+    "has_file": False,
+    "can_upgrade_quality": False,
+}
 
 
 def _truncate_overview(overview: Optional[str]) -> Optional[str]:
@@ -142,6 +166,18 @@ def refresh_weekly_data_from_radarr(
                 radarr_movie = movies_by_tmdb_id.get(stored_tmdb_id)
 
             if not radarr_movie:
+                if existing_radarr_id:
+                    # Was linked to Radarr but no longer resolves (deleted in
+                    # Radarr): reset to the not-in-Radarr shape, keeping the
+                    # display metadata, and count it as a change.
+                    changed = False
+                    for key, value in _UNLINKED_FIELDS.items():
+                        if stored_movie.get(key) != value:
+                            stored_movie[key] = value
+                            changed = True
+                    if changed:
+                        movies_refreshed += 1
+                        file_updated = True
                 continue
 
             was_unmatched = not existing_radarr_id
@@ -166,8 +202,7 @@ def refresh_weekly_data_from_radarr(
                 1 for movie in data.get("movies", []) if movie.get("radarr_id")
             )
             data["status_refreshed_at"] = datetime.now().isoformat()
-            with open(json_file, "w") as f:
-                json.dump(data, f, indent=2, default=str)
+            atomic_write_json(json_file, data, indent=2, default=str)
             weeks_updated += 1
 
         if progress_callback:

--- a/src/core/scheduler.py
+++ b/src/core/scheduler.py
@@ -13,13 +13,14 @@ from apscheduler.events import EVENT_JOB_ERROR, EVENT_JOB_EXECUTED
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
+from ..utils.atomic import atomic_write_json
 from ..utils.config import settings
 from ..utils.logger import get_logger
 from .auto_add import auto_add_missing_movies
 from .boxoffice import BoxOfficeService
 from .exceptions import SchedulerError
 from .json_generator import WeeklyDataGenerator
-from .library_sync import refresh_weekly_data_from_radarr
+from .library_sync import WEEKLY_WRITE_LOCK, refresh_weekly_data_from_radarr
 from .matcher import MatchResult, MovieMatcher
 from .models import MovieStatus
 from .radarr import RadarrService, get_all_movies_with_optional_cache_bypass
@@ -148,6 +149,15 @@ class BoxarrScheduler:
             logger.info("Starting scheduled box office update for previous week")
         start_time = datetime.now()
 
+        # Serialize against other weekly-JSON mutators (manual trigger, button
+        # refresh, /update-week). A concurrent caller fails fast rather than
+        # racing writes to the same file.
+        if not WEEKLY_WRITE_LOCK.acquire(blocking=False):
+            logger.warning(
+                "Another weekly update is already in progress; skipping this run"
+            )
+            raise SchedulerError("Another weekly update is already in progress")
+
         try:
             # Initialize services if needed
             if not self.boxoffice_service:
@@ -271,6 +281,8 @@ class BoxarrScheduler:
         except Exception as e:
             logger.error(f"Box office update failed: {e}")
             raise SchedulerError(f"Update failed: {e}") from e
+        finally:
+            WEEKLY_WRITE_LOCK.release()
 
     async def _run_in_executor(self, func: Callable, *args) -> Any:
         """Run blocking function in executor."""
@@ -370,13 +382,11 @@ class BoxarrScheduler:
 
             # Save to file
             history_file = history_dir / filename
-            with open(history_file, "w") as f:
-                json.dump(results, f, indent=2, default=str)
+            atomic_write_json(history_file, results, indent=2, default=str)
 
             # Also save as latest
             latest_file = history_dir / f"{year}W{week:02d}_latest.json"
-            with open(latest_file, "w") as f:
-                json.dump(results, f, indent=2, default=str)
+            atomic_write_json(latest_file, results, indent=2, default=str)
 
             logger.debug(f"Saved history to {history_file}")
 

--- a/src/utils/atomic.py
+++ b/src/utils/atomic.py
@@ -24,6 +24,13 @@ def atomic_write_json(path: Union[str, Path], data: Any, **json_kwargs: Any) -> 
     try:
         with open(tmp_fd, "w") as handle:
             json.dump(data, handle, **json_kwargs)
+            handle.flush()
+            os.fsync(handle.fileno())
+        # mkstemp creates the temp file 0600; relax to the standard 0644
+        # (honouring the process umask) so replaced files keep readable perms.
+        umask = os.umask(0)
+        os.umask(umask)
+        os.chmod(tmp_path, 0o666 & ~umask)
         os.replace(tmp_path, target)
     except BaseException:
         tmp_path.unlink(missing_ok=True)

--- a/src/utils/atomic.py
+++ b/src/utils/atomic.py
@@ -1,0 +1,30 @@
+"""Atomic JSON file writes.
+
+Writing ``config/weekly_pages/*.json`` (and scheduler history) with a plain
+``open(path, "w")`` + ``json.dump`` leaves a truncated file if the process is
+interrupted mid-write, which readers then fail to parse. ``atomic_write_json``
+writes to a temporary file in the same directory and ``os.replace()``s it into
+place — an atomic rename on POSIX and Windows — so readers only ever observe a
+complete file.
+"""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Union
+
+
+def atomic_write_json(path: Union[str, Path], data: Any, **json_kwargs: Any) -> None:
+    """Serialize ``data`` to ``path`` atomically via a same-directory temp file."""
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_name = tempfile.mkstemp(dir=target.parent, suffix=".tmp")
+    tmp_path = Path(tmp_name)
+    try:
+        with open(tmp_fd, "w") as handle:
+            json.dump(data, handle, **json_kwargs)
+        os.replace(tmp_path, target)
+    except BaseException:
+        tmp_path.unlink(missing_ok=True)
+        raise

--- a/tests/integration/test_weekly_page_corrupt.py
+++ b/tests/integration/test_weekly_page_corrupt.py
@@ -1,0 +1,23 @@
+"""Integration test: a corrupt weekly JSON file degrades gracefully, not 500."""
+
+from fastapi.testclient import TestClient
+
+from src.api.app import create_app
+
+
+def test_serve_weekly_page_with_corrupt_json_returns_404(tmp_path, monkeypatch):
+    monkeypatch.setattr("src.utils.config.settings.boxarr_data_directory", tmp_path)
+
+    weekly_pages_dir = tmp_path / "weekly_pages"
+    weekly_pages_dir.mkdir(parents=True)
+    # Simulate a truncated/interrupted write.
+    (weekly_pages_dir / "2024W10.json").write_text('{"year": 2024, "week": 10, "mov')
+
+    app = create_app()
+    # raise_server_exceptions defaults to True, so an unhandled 500 would raise.
+    client = TestClient(app)
+
+    response = client.get("/2024W10")
+
+    assert response.status_code == 404
+    assert "corrupt" in response.json()["detail"].lower()

--- a/tests/unit/test_atomic.py
+++ b/tests/unit/test_atomic.py
@@ -1,0 +1,51 @@
+"""Tests for the atomic JSON write helper."""
+
+import json
+
+import pytest
+
+from src.utils import atomic
+from src.utils.atomic import atomic_write_json
+
+
+def test_atomic_write_json_writes_content(tmp_path):
+    target = tmp_path / "sub" / "data.json"
+
+    atomic_write_json(target, {"a": 1, "b": [2, 3]}, indent=2)
+
+    assert target.exists()
+    assert json.loads(target.read_text()) == {"a": 1, "b": [2, 3]}
+
+
+def test_atomic_write_json_uses_os_replace(tmp_path, monkeypatch):
+    target = tmp_path / "data.json"
+    calls = []
+    real_replace = atomic.os.replace
+
+    def _spy_replace(src, dst):
+        calls.append((str(src), str(dst)))
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(atomic.os, "replace", _spy_replace)
+
+    atomic_write_json(target, {"ok": True})
+
+    assert len(calls) == 1
+    src_name, dst_name = calls[0]
+    assert dst_name == str(target)
+    assert src_name.endswith(".tmp")
+    assert json.loads(target.read_text()) == {"ok": True}
+
+
+def test_atomic_write_json_leaves_target_intact_on_failure(tmp_path):
+    target = tmp_path / "data.json"
+    atomic_write_json(target, {"original": True})
+
+    # object() is not JSON-serializable, so json.dump raises mid-write.
+    with pytest.raises(TypeError):
+        atomic_write_json(target, {"bad": object()})
+
+    # The pre-existing file must be untouched (not truncated) ...
+    assert json.loads(target.read_text()) == {"original": True}
+    # ... and the aborted temp file must be cleaned up.
+    assert list(tmp_path.glob("*.tmp")) == []

--- a/tests/unit/test_weekly_json_integrity.py
+++ b/tests/unit/test_weekly_json_integrity.py
@@ -1,0 +1,175 @@
+"""Tests for weekly-JSON integrity: shared write lock and Radarr un-linking."""
+
+import json
+
+from src.core.library_sync import WEEKLY_WRITE_LOCK, refresh_weekly_data_from_radarr
+from src.core.models import MovieStatus
+
+
+class _FakeProfile:
+    def __init__(self, profile_id: int, name: str):
+        self.id = profile_id
+        self.name = name
+
+
+class _FakeRadarrService:
+    def __init__(self, movies, profiles):
+        self._movies = movies
+        self._profiles = profiles
+
+    def get_all_movies(self, ignore_cache: bool = False):
+        return self._movies
+
+    def get_quality_profiles(self):
+        return self._profiles
+
+
+def test_weekly_write_lock_is_shared_across_mutator_modules():
+    from src.api.routes import movies as movies_route
+    from src.api.routes import scheduler as scheduler_route
+    from src.core import scheduler as scheduler_core
+
+    assert scheduler_core.WEEKLY_WRITE_LOCK is WEEKLY_WRITE_LOCK
+    assert movies_route.WEEKLY_WRITE_LOCK is WEEKLY_WRITE_LOCK
+    assert scheduler_route.WEEKLY_WRITE_LOCK is WEEKLY_WRITE_LOCK
+
+
+def test_refresh_unlinks_movie_deleted_from_radarr(tmp_path, monkeypatch):
+    weekly_pages_dir = tmp_path / "weekly_pages"
+    weekly_pages_dir.mkdir()
+
+    week_file = weekly_pages_dir / "2024W10.json"
+    with open(week_file, "w") as f:
+        json.dump(
+            {
+                "generated_at": "2026-04-05T10:00:00",
+                "year": 2024,
+                "week": 10,
+                "matched_movies": 1,
+                "movies": [
+                    {
+                        "title": "Deleted In Radarr",
+                        "radarr_id": 101,
+                        "radarr_title": "Deleted In Radarr",
+                        "tmdb_id": 1001,
+                        "status": "Downloaded",
+                        "status_color": "#48bb78",
+                        "status_icon": "✅",
+                        "quality_profile_id": 1,
+                        "quality_profile_name": "HD-1080p",
+                        "has_file": True,
+                        "can_upgrade_quality": False,
+                        "poster": "https://example.com/101.jpg",
+                        "year": 2024,
+                        "genres": "Action, Adventure",
+                        "overview": "A film that was later deleted.",
+                        "imdb_id": "tt101",
+                        "original_language": "English",
+                    }
+                ],
+            },
+            f,
+            indent=2,
+        )
+
+    monkeypatch.setattr(
+        "src.core.library_sync.settings.boxarr_features_quality_upgrade", True
+    )
+    monkeypatch.setattr(
+        "src.core.library_sync.settings.radarr_quality_profile_upgrade", "Ultra-HD"
+    )
+
+    # Radarr library no longer contains id 101 / tmdb 1001.
+    fake_service = _FakeRadarrService(
+        movies=[],
+        profiles=[_FakeProfile(1, "HD-1080p"), _FakeProfile(2, "Ultra-HD")],
+    )
+
+    results = refresh_weekly_data_from_radarr(
+        radarr_service=fake_service,
+        data_directory=tmp_path,
+        ignore_cache=True,
+    )
+
+    assert results["weeks_updated"] == 1
+    assert results["movies_refreshed"] == 1
+    assert results["movies_linked"] == 0
+
+    with open(week_file) as f:
+        refreshed = json.load(f)
+
+    movie = refreshed["movies"][0]
+    # Radarr link fields are cleared ...
+    assert movie["radarr_id"] is None
+    assert movie["radarr_title"] is None
+    assert movie["status"] == "Not in Radarr"
+    assert movie["status_color"] == "#718096"
+    assert movie["status_icon"] == "➕"
+    assert movie["quality_profile_id"] is None
+    assert movie["quality_profile_name"] is None
+    assert movie["has_file"] is False
+    assert movie["can_upgrade_quality"] is False
+    # ... while display metadata is preserved.
+    assert movie["title"] == "Deleted In Radarr"
+    assert movie["tmdb_id"] == 1001
+    assert movie["year"] == 2024
+    assert movie["poster"] == "https://example.com/101.jpg"
+
+    assert refreshed["matched_movies"] == 0
+
+
+def test_refresh_leaves_already_unmatched_entry_unchanged(tmp_path, monkeypatch):
+    weekly_pages_dir = tmp_path / "weekly_pages"
+    weekly_pages_dir.mkdir()
+
+    week_file = weekly_pages_dir / "2024W11.json"
+    original = {
+        "generated_at": "2026-04-05T10:00:00",
+        "year": 2024,
+        "week": 11,
+        "matched_movies": 0,
+        "movies": [
+            {
+                "title": "Never In Radarr",
+                "radarr_id": None,
+                "tmdb_id": None,
+                "status": "Not in Radarr",
+                "status_color": "#718096",
+                "status_icon": "➕",
+                "quality_profile_id": None,
+                "quality_profile_name": None,
+                "has_file": False,
+                "can_upgrade_quality": False,
+                "poster": None,
+                "year": 2024,
+                "genres": None,
+                "overview": None,
+                "imdb_id": None,
+                "original_language": None,
+            }
+        ],
+    }
+    with open(week_file, "w") as f:
+        json.dump(original, f, indent=2)
+
+    monkeypatch.setattr(
+        "src.core.library_sync.settings.radarr_quality_profile_upgrade", "Ultra-HD"
+    )
+
+    fake_service = _FakeRadarrService(
+        movies=[],
+        profiles=[_FakeProfile(1, "HD-1080p")],
+    )
+
+    results = refresh_weekly_data_from_radarr(
+        radarr_service=fake_service,
+        data_directory=tmp_path,
+        ignore_cache=True,
+    )
+
+    assert results["weeks_updated"] == 0
+    assert results["movies_refreshed"] == 0
+
+    with open(week_file) as f:
+        after = json.load(f)
+    assert after == original


### PR DESCRIPTION
## Problem

Weekly box-office pages could break in two ways:

1. **Corrupted / half-written pages.** Weekly JSON files (and scheduler history) were written with a plain `open(path, "w")` + `json.dump`. If the process was interrupted mid-write — or two updates ran concurrently — the file was left truncated. Readers then hit an unhandled parse error, so opening a week returned a hard **500 Internal Server Error** and the widget endpoints failed entirely.
2. **Movies deleted from Radarr stayed "in Radarr" forever.** When a film was removed from the Radarr library, its stored weekly entry kept its old `radarr_id`, status, quality and "has file" flags, so the UI kept showing it as managed even though it no longer existed.

## Root cause

- Non-atomic writes: a truncated file is observable by any concurrent or subsequent reader.
- Unguarded reads: `serve_weekly_page` and the widget endpoints assumed the JSON always parsed.
- Unserialized mutators: multiple code paths (Tuesday cron, manual refresh button, `/update-week`) could write the same weekly files at once.
- The refresh routine never reconciled entries whose `radarr_id` no longer resolved in the live Radarr library.

## Change

- **Atomic writes** (`src/utils/atomic.py`): new `atomic_write_json()` writes a same-directory temp file, `fsync`s it, restores standard `0644` permissions, then `os.replace()`s it into place — an atomic rename, so readers only ever see a complete file. Every weekly-JSON and scheduler-history writer now routes through it (`json_generator`, `library_sync`, `scheduler`, and the admin metadata-repair path).
- **Corruption-safe reads**: `serve_weekly_page` now returns a clean **404 "Week data is unavailable or corrupted"** instead of a 500 on a bad file; the widget endpoints iterate newest-first and skip any file that fails to parse, degrading to empty widget data.
- **Serialized mutators**: a single shared, non-reentrant `WEEKLY_WRITE_LOCK` (acquired non-blocking, so the asyncio event loop is never blocked) serializes the cron update, the refresh button, and `/update-week`; a busy writer fails fast with a "retry shortly" response rather than racing.
- **Radarr un-linking**: `refresh_weekly_data_from_radarr` now resets entries whose `radarr_id` no longer resolves back to the canonical "not in Radarr" shape (clearing `radarr_id`/status/quality/`has_file`/`can_upgrade` while preserving title/tmdb/year/poster), counts them as changes, and recomputes `matched_movies`. Already-unmatched entries are left byte-identical.

## Testing

- Full suite: **148 passed, 1 skipped** (baseline 141 + 1; +7 new tests, 0 failures).
- Quality gates clean: `black --check`, `isort --check-only`, `flake8 --select=E9,F63,F7,F82 src/`, `mypy src/ --ignore-missing-imports --no-strict-optional`.
- New tests: `tests/unit/test_atomic.py` (atomic replace + temp cleanup on failure), `tests/unit/test_weekly_json_integrity.py` (shared lock identity; deleted-from-Radarr reset + idempotence), `tests/integration/test_weekly_page_corrupt.py` (corrupt weekly JSON returns 404, not 500).
