### PR TITLE
chore: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.8.0] - 2026-07-23
+## [2.0.0] - 2026-07-23
 
 ### Added
 - **Selectable Box Office Region**: New setup dropdown to pick a Box Office Mojo region, driving an `?area=CODE` query so charts can track box office beyond US & Canada domestic (#109, #112)
@@ -16,9 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Ignore Button**: Fixed single-quote escaping in the overview ignore-button `onclick` handler so movies with apostrophes in their titles can be ignored (#106, #111)
 - **Event-Loop Blocking**: Manual box office routes now offload the blocking Box Office Mojo scraper to a worker thread, so a wedged upstream (compounded by request retries) no longer stalls the asyncio event loop and hangs every request, including `/api/health`
 - **Timeout Preservation on Save**: Saving configuration from the settings UI now preserves the `boxoffice_timeout` (and Radarr request timeout) value instead of silently reverting it to the default
+- **Correct Auto-Add Match**: Auto-add now selects the Radarr lookup result by IMDb id instead of the first candidate, preventing the wrong movie from being added (#115)
+- **Year-Boundary Navigation**: Fixed previous-week navigation across the year boundary and URL-encoded the overview search links so titles with special characters resolve correctly (#116)
+- **XSS Hardening**: Escaped dynamic widget output and switched toast rendering to a safe path so untrusted values can no longer inject markup (#117)
+- **Sequel Mismatch**: The matcher no longer links a charting sequel to the original film already in the library (#118)
 
 ### Changed
 - **Health-Check Logging**: Suppressed `uvicorn.access` log lines for `/api/health` to keep logs readable under frequent health probes (#107)
+- **Config Resilience**: A corrupt `local.yaml` no longer crashes the app — the loader falls back to setup mode, backs up the unreadable file as `.broken`, and writes config atomically (#119)
+- **Weekly JSON Integrity**: Weekly page data is now written atomically and read corruption-safe, writers are serialized under a shared lock, and movies deleted from Radarr are un-linked from stored weeks (#120)
 
 ## [1.7.0] - 2026-04-05
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "boxarr"
-version = "1.8.0"
+version = "2.0.0"
 description = "Box Office Tracking for Radarr"
 readme = "README.md"
 license = {text = "GPL-3.0"}

--- a/src/api/routes/config.py
+++ b/src/api/routes/config.py
@@ -332,6 +332,8 @@ async def save_configuration(config: SaveConfigRequest):
         try:
             with open(tmp_fd, "w") as f:
                 yaml.dump(config_data, f, default_flow_style=False)
+                f.flush()
+                os.fsync(f.fileno())
             os.replace(tmp_path, config_path)
         except Exception:
             Path(tmp_path).unlink(missing_ok=True)

--- a/src/api/routes/movies.py
+++ b/src/api/routes/movies.py
@@ -547,53 +547,67 @@ async def add_movie_to_radarr(request: AddMovieRequest):
 
 def regenerate_weeks_with_movie(movie_title: str):
     """Find and regenerate all weeks containing a specific movie."""
-    weekly_pages_dir = Path(settings.boxarr_data_directory) / "weekly_pages"
-    radarr_service = RadarrService()
-    generator = WeeklyDataGenerator(radarr_service)
+    if not WEEKLY_WRITE_LOCK.acquire(blocking=False):
+        logger.info(
+            "Another weekly update is in progress; skipping regeneration after "
+            f"adding {movie_title} (weekly pages will catch up on the next refresh)"
+        )
+        return
+    try:
+        weekly_pages_dir = Path(settings.boxarr_data_directory) / "weekly_pages"
+        radarr_service = RadarrService()
+        generator = WeeklyDataGenerator(radarr_service)
 
-    # Get updated Radarr library
-    # Always bypass cache so recently added movies are visible to the matcher
-    radarr_movies = get_all_movies_with_optional_cache_bypass(
-        radarr_service, ignore_cache=True
-    )
+        # Get updated Radarr library
+        # Always bypass cache so recently added movies are visible to the matcher
+        radarr_movies = get_all_movies_with_optional_cache_bypass(
+            radarr_service, ignore_cache=True
+        )
 
-    # Search all metadata files
-    for json_file in weekly_pages_dir.glob("*.json"):
-        try:
-            with open(json_file) as f:
-                metadata = json.load(f)
+        # Search all metadata files
+        for json_file in weekly_pages_dir.glob("*.json"):
+            try:
+                with open(json_file) as f:
+                    metadata = json.load(f)
 
-            # Check if this week contains the movie
-            movie_found = False
-            for movie in metadata.get("movies", []):
-                if movie_title.lower() in movie.get("title", "").lower():
-                    movie_found = True
-                    break
+                # Check if this week contains the movie
+                movie_found = False
+                for movie in metadata.get("movies", []):
+                    if movie_title.lower() in movie.get("title", "").lower():
+                        movie_found = True
+                        break
 
-            if movie_found:
-                # Regenerate this week's page
-                year = metadata["year"]
-                week = metadata["week"]
-                logger.info(
-                    f"Regenerating week {year}W{week:02d} after adding {movie_title}"
-                )
+                if movie_found:
+                    # Regenerate this week's page
+                    year = metadata["year"]
+                    week = metadata["week"]
+                    logger.info(
+                        f"Regenerating week {year}W{week:02d} after adding "
+                        f"{movie_title}"
+                    )
 
-                # The generator will re-match with updated Radarr data
-                from ...core.boxoffice import BoxOfficeService
-                from ...core.matcher import MovieMatcher
+                    # The generator will re-match with updated Radarr data
+                    from ...core.boxoffice import BoxOfficeService
+                    from ...core.matcher import MovieMatcher
 
-                boxoffice_service = BoxOfficeService()
-                matcher = MovieMatcher()
+                    boxoffice_service = BoxOfficeService()
+                    matcher = MovieMatcher()
 
-                # Get week's data
-                box_office_movies = boxoffice_service.fetch_weekend_box_office(
-                    year, week
-                )
-                matcher.build_movie_index(radarr_movies)
-                match_results = matcher.match_movies(box_office_movies, radarr_movies)
+                    # Get week's data
+                    box_office_movies = boxoffice_service.fetch_weekend_box_office(
+                        year, week
+                    )
+                    matcher.build_movie_index(radarr_movies)
+                    match_results = matcher.match_movies(
+                        box_office_movies, radarr_movies
+                    )
 
-                # Generate updated data file
-                generator.generate_weekly_data(match_results, year, week, radarr_movies)
-        except Exception as e:
-            logger.error(f"Error processing {json_file}: {e}")
-            continue
+                    # Generate updated data file
+                    generator.generate_weekly_data(
+                        match_results, year, week, radarr_movies
+                    )
+            except Exception as e:
+                logger.error(f"Error processing {json_file}: {e}")
+                continue
+    finally:
+        WEEKLY_WRITE_LOCK.release()

--- a/src/api/routes/web.py
+++ b/src/api/routes/web.py
@@ -780,10 +780,9 @@ async def get_available_weeks() -> List[WeekInfo]:
             year = metadata["year"]
             week = metadata["week"]
 
-            # Get first day of week (Monday)
-            jan1 = datetime(year, 1, 1)
-            week_start = jan1 + timedelta(weeks=week - 1)
-            week_start -= timedelta(days=week_start.weekday())
+            # Get first day of week (ISO Monday), matching serve_weekly_page
+            # and the JSON generator so the overview and week pages agree.
+            week_start = date.fromisocalendar(year, week, 1)
             week_end = week_start + timedelta(days=6)
 
             date_range = (

--- a/src/core/ignore_list.py
+++ b/src/core/ignore_list.py
@@ -1,6 +1,7 @@
 """Ignore list manager for permanently skipping movies."""
 
 import json
+import os
 import tempfile
 from datetime import datetime
 from pathlib import Path
@@ -51,6 +52,8 @@ class IgnoreList:
             try:
                 with open(tmp_fd, "w") as f:
                     json.dump(entries, f, indent=2)
+                    f.flush()
+                    os.fsync(f.fileno())
                 Path(tmp_path).replace(self._file_path)
             except Exception:
                 Path(tmp_path).unlink(missing_ok=True)

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import re
 import sys
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -15,13 +16,23 @@ from typing import Optional
 # *arr apps suppress health-endpoint access from their own log output.
 _HEALTHCHECK_PATHS = {"/api/health"}
 
+# uvicorn.access lines embed the request line as ``"METHOD TARGET HTTP/x.y"``.
+# Capture the space-delimited request target so we can match the path exactly
+# rather than testing for a bare substring (which would also suppress e.g.
+# ``/api/health-report`` or ``/movies?next=/api/health``).
+_ACCESS_REQUEST_TARGET_RE = re.compile(r'"\S+\s+(?P<target>\S+)\s+HTTP/')
+
 
 class _HealthCheckFilter(logging.Filter):
     """Drop uvicorn access-log records for health-check endpoints."""
 
     def filter(self, record: logging.LogRecord) -> bool:
-        msg = record.getMessage()
-        return not any(path in msg for path in _HEALTHCHECK_PATHS)
+        match = _ACCESS_REQUEST_TARGET_RE.search(record.getMessage())
+        if match is None:
+            return True
+        # Strip any query string; match only the path component.
+        path = match.group("target").split("?", 1)[0]
+        return path not in _HEALTHCHECK_PATHS
 
 
 def setup_logging(

--- a/src/version.py
+++ b/src/version.py
@@ -49,7 +49,7 @@ def get_version() -> str:
                         version = f"{base_version}-dev"
                 else:
                     # Just a commit hash, use fallback
-                    version = "1.8.0-dev"
+                    version = "2.0.0-dev"
 
             return version
 
@@ -59,7 +59,7 @@ def get_version() -> str:
 
     # Fallback version for when git is not available (e.g., in Docker)
     # This should be updated when creating a new release
-    return "1.8.0"
+    return "2.0.0"
 
 
 # Cache the version at import time

--- a/src/web/static/js/app.js
+++ b/src/web/static/js/app.js
@@ -30,6 +30,16 @@ function isCurrentPath(targetPath) {
     return currentPath === expectedPath;
 }
 
+// Escape admin/user-supplied text before interpolating into innerHTML templates.
+function escapeHtml(value) {
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
 // Helper to get path without base
 function getPathWithoutBase() {
     const currentPath = window.location.pathname;
@@ -965,13 +975,13 @@ function reloadScheduler() {
             return `
             <div class="mapping-rule" style="display: grid; grid-template-columns: 2fr auto 2fr 100px 120px; gap: 1rem; align-items: center; padding: 0.75rem; margin-bottom: 0.5rem; background: var(--bg-primary); border: 1px solid var(--border-color); border-radius: 6px; transition: background 0.2s;">
                 <div style="font-weight: 500; color: var(--text-primary);">
-                    ${mapping.genres.join(', ')}
+                    ${escapeHtml(mapping.genres.join(', '))}
                 </div>
                 <div style="color: var(--text-muted); text-align: center;">
                     →
                 </div>
                 <div style="display: flex; align-items: center; color: var(--primary-color);">
-                    <span>${mapping.root_folder}</span>
+                    <span>${escapeHtml(mapping.root_folder)}</span>
                     ${warningIcon}
                 </div>
                 <div>

--- a/tests/unit/test_available_weeks_range.py
+++ b/tests/unit/test_available_weeks_range.py
@@ -1,0 +1,54 @@
+"""Tests for ISO-correct date ranges on the dashboard week list.
+
+``get_available_weeks`` previously derived the week's Monday from naive
+``date(year, 1, 1) + timedelta`` arithmetic, which disagreed with the ISO
+calendar the week pages use. For 2021 W01 that rendered ``Dec 28 - Jan 03``
+while the week page correctly rendered the Jan 04-10 range. The range now comes
+from ``date.fromisocalendar`` so both views agree.
+"""
+
+import json
+
+import pytest
+
+from src.api.routes import web
+
+
+def _write_week(weekly_pages_dir, year, week):
+    week_file = weekly_pages_dir / f"{year}W{week:02d}.json"
+    with open(week_file, "w") as f:
+        json.dump(
+            {
+                "generated_at": "2026-01-01T10:00:00",
+                "year": year,
+                "week": week,
+                "movies": [],
+            },
+            f,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "year,week,expected",
+    [
+        (2021, 1, "Jan 04 - Jan 10, 2021"),
+        (2019, 1, "Dec 31 - Jan 06, 2019"),
+        (2020, 25, "Jun 15 - Jun 21, 2020"),
+    ],
+)
+async def test_date_range_uses_iso_calendar(
+    tmp_path, monkeypatch, year, week, expected
+):
+    weekly_pages_dir = tmp_path / "weekly_pages"
+    weekly_pages_dir.mkdir()
+    _write_week(weekly_pages_dir, year, week)
+
+    monkeypatch.setattr(web.settings, "boxarr_data_directory", str(tmp_path))
+
+    weeks = await web.get_available_weeks()
+
+    assert len(weeks) == 1
+    assert weeks[0].year == year
+    assert weeks[0].week == week
+    assert weeks[0].date_range == expected

--- a/tests/unit/test_config_resilience.py
+++ b/tests/unit/test_config_resilience.py
@@ -3,7 +3,7 @@
 A malformed or wrong-typed ``local.yaml`` must never crash startup. The loader
 should back up the unreadable file and boot with defaults (setup mode), and it
 should skip individual values that fail validation rather than aborting.
-Related: hardening for v1.8.0.
+Related: hardening for v2.0.0.
 """
 
 import os

--- a/tests/unit/test_logger_healthcheck_filter.py
+++ b/tests/unit/test_logger_healthcheck_filter.py
@@ -1,0 +1,59 @@
+"""Tests for the uvicorn access-log health-check filter.
+
+The filter must match the request target of a uvicorn access line exactly (the
+path, optionally with a query string) so it suppresses ``/api/health`` probes
+without also hiding lookalike paths such as ``/api/health-report`` or a request
+whose query string merely mentions ``/api/health``.
+"""
+
+import logging
+
+from src.utils.logger import _HealthCheckFilter
+
+
+def _access_record(request_line: str) -> logging.LogRecord:
+    """Build a uvicorn.access-style record for the given request line."""
+    return logging.LogRecord(
+        name="uvicorn.access",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg='%s - "%s" %s',
+        args=("127.0.0.1:52345", request_line, "200"),
+        exc_info=None,
+    )
+
+
+class TestHealthCheckFilter:
+    def setup_method(self):
+        self.filter = _HealthCheckFilter()
+
+    def test_health_path_suppressed(self):
+        assert self.filter.filter(_access_record("GET /api/health HTTP/1.1")) is False
+
+    def test_health_path_with_query_suppressed(self):
+        record = _access_record("GET /api/health?x=1 HTTP/1.1")
+        assert self.filter.filter(record) is False
+
+    def test_health_report_not_suppressed(self):
+        record = _access_record("GET /api/health-report HTTP/1.1")
+        assert self.filter.filter(record) is True
+
+    def test_query_string_mentioning_health_not_suppressed(self):
+        record = _access_record("GET /movies?next=/api/health HTTP/1.1")
+        assert self.filter.filter(record) is True
+
+    def test_normal_request_passes(self):
+        assert self.filter.filter(_access_record("GET /movies HTTP/1.1")) is True
+
+    def test_non_access_line_passes(self):
+        record = logging.LogRecord(
+            name="uvicorn.access",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="Application startup complete.",
+            args=None,
+            exc_info=None,
+        )
+        assert self.filter.filter(record) is True

--- a/tests/unit/test_regenerate_weeks_lock.py
+++ b/tests/unit/test_regenerate_weeks_lock.py
@@ -1,0 +1,66 @@
+"""Tests for the weekly-JSON write lock guarding ``regenerate_weeks_with_movie``.
+
+The add-movie path regenerates affected weekly pages in a worker thread. That
+worker mutates weekly JSON and so must honour the shared ``WEEKLY_WRITE_LOCK``
+like the other four mutators: acquire non-blocking, and if another writer holds
+it, skip regeneration gracefully (the movie is already in Radarr; weekly pages
+catch up on the next refresh).
+"""
+
+import logging
+
+from src.api.routes import movies as movies_route
+from src.core.library_sync import WEEKLY_WRITE_LOCK
+
+
+class _Boom:
+    def __init__(self, *args, **kwargs):
+        raise AssertionError("regeneration work must not run while lock is held")
+
+
+def test_regeneration_skipped_when_lock_held(monkeypatch, caplog):
+    # Prove the worker never reaches its regeneration work while the lock is busy.
+    monkeypatch.setattr(movies_route, "RadarrService", _Boom)
+
+    assert WEEKLY_WRITE_LOCK.acquire(blocking=False)
+    try:
+        with caplog.at_level(logging.INFO, logger="src.api.routes.movies"):
+            result = movies_route.regenerate_weeks_with_movie("Some Movie")
+    finally:
+        WEEKLY_WRITE_LOCK.release()
+
+    assert result is None
+    assert any(
+        "skipping regeneration" in record.getMessage() for record in caplog.records
+    )
+
+
+def test_regeneration_runs_and_releases_lock_when_free(tmp_path, monkeypatch):
+    weekly_pages_dir = tmp_path / "weekly_pages"
+    weekly_pages_dir.mkdir()
+
+    calls = {"radarr": 0, "library": 0}
+
+    class _FakeRadarr:
+        def __init__(self, *args, **kwargs):
+            calls["radarr"] += 1
+
+    def _fake_library(service, ignore_cache=False):
+        calls["library"] += 1
+        return []
+
+    monkeypatch.setattr(movies_route, "RadarrService", _FakeRadarr)
+    monkeypatch.setattr(movies_route, "WeeklyDataGenerator", _FakeRadarr)
+    monkeypatch.setattr(
+        movies_route, "get_all_movies_with_optional_cache_bypass", _fake_library
+    )
+    monkeypatch.setattr(movies_route.settings, "boxarr_data_directory", str(tmp_path))
+
+    movies_route.regenerate_weeks_with_movie("Some Movie")
+
+    # The worker proceeded with its normal work ...
+    assert calls["radarr"] >= 1
+    assert calls["library"] == 1
+    # ... and released the lock so subsequent writers can acquire it.
+    assert WEEKLY_WRITE_LOCK.acquire(blocking=False)
+    WEEKLY_WRITE_LOCK.release()


### PR DESCRIPTION
## Summary

Cuts the **v2.0.0** release. Renames the version across the codebase to `2.0.0`, completes the `[2.0.0]` CHANGELOG section documenting the release's hardening PRs, and resolves the five verified code minors from the final pre-release audit sweep.

## Changes

**Version rename to 2.0.0**
- `pyproject.toml` version -> `2.0.0`; `src/version.py` fallback/return -> `2.0.0`
- `CHANGELOG.md` header -> `## [2.0.0] - 2026-07-23`
- Test docstring reference updated to v2.0.0

**CHANGELOG completion** — documents the six hardening PRs under `[2.0.0]`: Fixed #115 (IMDb-id lookup selection), #116 (year-boundary nav + URL-encoded search links), #117 (XSS hardening), #118 (sequel mismatch); Changed #119 (config resilience), #120 (weekly-JSON integrity).

**Code minors from the pre-release sweep**
- Weekly-JSON write serialization: wrapped the 5th mutator `regenerate_weeks_with_movie` in the non-blocking `WEEKLY_WRITE_LOCK` inside the threaded worker (never across an await); skips gracefully on lock-busy while add-movie still succeeds.
- Health-check log filter: `_HealthCheckFilter` now regex-parses the uvicorn access request target, strips the query string, and matches the path exactly against the kept health-check set.
- ISO week ranges: `get_available_weeks` derives `week_start` via `date.fromisocalendar(year, week, 1)`, matching the other week renderers; display format unchanged.
- XSS hardening: added a shared `escapeHtml` helper in `app.js`, applied to the two dynamic root-folder mapping values in `renderMappingsList`.
- Durability: added `f.flush()` + `os.fsync()` before `os.replace` in the `config.py` save and `ignore_list.py` `_save` atomic writers.

## Deferred (by design)
- The CD workflow double-trigger quirk is left untouched by design (out of scope for this release).
- Wiki documentation update follows the release.

## Testing
- pytest `tests/`: **219 passed, 1 skipped** (208 baseline + 11 new tests for the lock guard, health-check path matching, and ISO week ranges)
- flake8 `--select=E9,F63,F7,F82`: clean
- mypy `src/`: Success, no issues in 28 source files
- black + isort: clean on all touched files

