### PR TITLE
fix: run create-release job when upstream run-ci is skipped

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -101,7 +101,7 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: build-and-push
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: always() && needs.build-and-push.result == 'success' && startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
       


### PR DESCRIPTION
## Problem
The v2.0.0 tag push built and published the Docker images, but the **Create GitHub Release job was silently skipped** — the release object had to be created manually.

## Root cause
The `run-ci` gating job added in #105 only runs on manual `workflow_dispatch`, so on tag pushes it reports `skipped`. `build-and-push` handles this with an `always() && (success || skipped)` guard, but `create-release`'s plain `if:` inherits the implicit `success()` over its needs chain, and a skipped transitive dependency makes GitHub skip the job. Releases before #105 predate the gating job, which is why v1.7.0 released normally.

## Change
One line: guard `create-release` with `always() && needs.build-and-push.result == 'success' && startsWith(github.ref, 'refs/tags/v')` — the same pattern `build-and-push` uses. Behavior is unchanged in every other respect: the job still only runs for `v*` tags after a successful image build.

## Testing
Condition-logic change only, verified by inspection against the v2.0.0 run (run-ci=skipped, build-and-push=success → old condition skipped the job; new condition runs it). Will be exercised by the next tag push.

